### PR TITLE
Ship the dashboard arrangement as the default, and show loading and scanning states

### DIFF
--- a/public/css/feedback.css
+++ b/public/css/feedback.css
@@ -8,6 +8,12 @@
   }
 }
 
+@keyframes zr-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+
 @layer components {
   /* meter / progress */
   .zr-meter {
@@ -158,9 +164,28 @@
     border-width: 3px;
   }
 
+  /* skeleton — a placeholder shaped like the thing it stands in for. A spinner
+     says "something is happening"; this says "a number goes here", which is
+     what a page full of figures needs while they are in flight. The sheen
+     itself is --zr-skeleton-bg in tokens.css, so the dashboard's loading state
+     can paint existing value slots with the same one. */
+  .zr-skeleton {
+    background: var(--zr-skeleton-bg) 0 0 / 200% 100%;
+    border-radius: var(--zr-r-sm);
+    animation: zr-shimmer 1.4s linear infinite;
+    /* Text inside stays as the accessible label but stops being drawn, so the
+       bar takes the width the real value will need. */
+    color: transparent;
+    user-select: none;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .zr-spinner {
       animation-duration: 2s;
+    }
+    /* The sheen is decoration; the placeholder shape carries the meaning. */
+    .zr-skeleton {
+      animation: none;
     }
   }
 

--- a/public/css/pages/dashboard.css
+++ b/public/css/pages/dashboard.css
@@ -14,6 +14,266 @@
     margin-bottom: var(--zr-4);
   }
 
+  /* --- loading state ------------------------------------------------------
+     Every figure on this page arrives from one fetch, so until it lands the
+     page is a grid of em dashes and empty boxes — which reads as "no data",
+     not as "still loading". The module carries data-loading until the stats
+     land (and drops it on failure too, where the stale banner takes over), and
+     these rules turn the slots that are about to be filled into placeholders
+     of the right shape. Selecting by the value classes rather than by id keeps
+     a new card covered without another rule. */
+  /* A width, not a min-width: these slots sit in flex rows that would otherwise
+     stretch the bar across the whole card, and a placeholder the size of a
+     paragraph does not read as "a number is coming". */
+  [data-module='dashboard'][data-loading] :is(.zr-stat__value, .zr-kv__v) {
+    display: inline-block;
+    width: 4ch;
+    color: transparent;
+    user-select: none;
+  }
+  [data-module='dashboard'][data-loading] .zr-entitybtn strong {
+    display: inline-block;
+    width: 3ch;
+    color: transparent;
+  }
+
+  /* The chart bodies are empty elements until their module draws into them, so
+     they need a height of their own to stand in for. */
+  [data-module='dashboard'][data-loading] .zr-donut {
+    width: var(--zr-donut-size, 112px);
+    height: var(--zr-donut-size, 112px);
+    border-radius: 50%;
+  }
+  [data-module='dashboard'][data-loading] .zr-spark {
+    height: 48px;
+  }
+  [data-module='dashboard'][data-loading] :is(.zr-barlist, .zr-list) {
+    min-height: 96px;
+  }
+  [data-module='dashboard'][data-loading] .zr-module__foot + .zr-list {
+    min-height: 132px;
+  }
+
+  /* The sheen itself comes from the same token the .zr-skeleton component
+     paints with, so there is one definition of what a placeholder looks like. */
+  [data-module='dashboard'][data-loading]
+    :is(
+      .zr-stat__value,
+      .zr-kv__v,
+      .zr-entitybtn strong,
+      .zr-donut,
+      .zr-spark,
+      .zr-barlist,
+      .zr-list
+    ) {
+    background: var(--zr-skeleton-bg) 0 0 / 200% 100%;
+    border-radius: var(--zr-r-sm);
+    animation: zr-shimmer 1.4s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-module='dashboard'][data-loading] * {
+      animation: none;
+    }
+  }
+
+  /* --- the runner seal ----------------------------------------------------
+     While a scan is on, the card shows the seal working through the pile: a
+     sheet lifts off the left stack, arcs over her, and lands on the sorted one
+     as the tick fires. Everything below only runs under .is-scanning, which
+     the module sets from the same state the scan buttons read — an idle card
+     paints nothing and animates nothing. */
+  .runner-seal {
+    display: none;
+    /* Shrinks with the card instead of disappearing from it: the scene stays
+       legible down to about a third of its size, and the status line beside it
+       keeps the room it needs because the seal never takes more than its
+       share. */
+    flex: 0 1 200px;
+    max-width: 42%;
+    min-width: 0;
+    margin: calc(var(--zr-2) * -1) 0;
+  }
+  .zr-module.is-scanning .runner-seal {
+    display: block;
+  }
+  .runner-seal svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .runner-seal__body {
+    transform-box: fill-box;
+    transform-origin: 50% 100%;
+    animation: seal-breathe 2.4s ease-in-out infinite;
+  }
+  .runner-seal__head {
+    transform-box: fill-box;
+    transform-origin: 50% 100%;
+    /* Her head follows the sheet across, then comes back for the next one. */
+    animation: seal-watch 2.4s ease-in-out infinite;
+  }
+  .runner-seal__eyes {
+    transform-box: fill-box;
+    transform-origin: 50% 50%;
+    animation: seal-blink 5.6s infinite;
+  }
+  .runner-seal__flipper {
+    transform-box: fill-box;
+    transform-origin: 90% 20%;
+    animation: seal-toss 2.4s ease-in-out infinite;
+  }
+  .runner-seal__tail {
+    transform-box: fill-box;
+    transform-origin: 10% 50%;
+    animation: seal-wag 2.4s ease-in-out infinite;
+  }
+  .runner-seal__sheet {
+    transform-box: view-box;
+    animation: seal-sheet 2.4s ease-in-out infinite;
+  }
+  .runner-seal__tick {
+    transform-box: fill-box;
+    transform-origin: 50% 50%;
+    animation: seal-tick 2.4s ease-in-out infinite;
+  }
+  .runner-seal__inbox {
+    animation: seal-pile-shrink 2.4s ease-in-out infinite;
+  }
+  .runner-seal__outbox rect:last-of-type {
+    transform-box: fill-box;
+    transform-origin: 50% 100%;
+    animation: seal-pile-grow 2.4s ease-in-out infinite;
+  }
+
+  @keyframes seal-breathe {
+    0%,
+    100% {
+      transform: translateY(0) scale(1, 1);
+    }
+    50% {
+      transform: translateY(-1.5px) scale(1.01, 0.99);
+    }
+  }
+  @keyframes seal-watch {
+    0%,
+    100% {
+      transform: rotate(-6deg);
+    }
+    45% {
+      transform: rotate(7deg);
+    }
+    70% {
+      transform: rotate(2deg);
+    }
+  }
+  @keyframes seal-blink {
+    0%,
+    92%,
+    97%,
+    100% {
+      transform: scaleY(1);
+    }
+    94% {
+      transform: scaleY(0.08);
+    }
+  }
+  @keyframes seal-toss {
+    0%,
+    100% {
+      transform: rotate(0deg);
+    }
+    18% {
+      transform: rotate(-24deg);
+    }
+    40% {
+      transform: rotate(6deg);
+    }
+  }
+  @keyframes seal-wag {
+    0%,
+    100% {
+      transform: rotate(0deg);
+    }
+    50% {
+      transform: rotate(-8deg);
+    }
+  }
+  /* The sheet starts on the left pile, rises over the seal and drops onto the
+     right one, tilting as it goes. Held out of sight either side of the throw
+     so the loop does not read as a sheet flying backwards. */
+  @keyframes seal-sheet {
+    0%,
+    8% {
+      transform: translate(38px, 58px) rotate(-6deg) scale(0.9);
+      opacity: 0;
+    }
+    14% {
+      transform: translate(44px, 52px) rotate(-4deg) scale(0.95);
+      opacity: 1;
+    }
+    46% {
+      transform: translate(100px, 18px) rotate(9deg) scale(1);
+      opacity: 1;
+    }
+    76% {
+      transform: translate(176px, 52px) rotate(3deg) scale(0.95);
+      opacity: 1;
+    }
+    84%,
+    100% {
+      transform: translate(176px, 58px) rotate(0deg) scale(0.9);
+      opacity: 0;
+    }
+  }
+  @keyframes seal-tick {
+    0%,
+    74%,
+    100% {
+      opacity: 0;
+      transform: scale(0.6);
+    }
+    80% {
+      opacity: 1;
+      transform: scale(1.1);
+    }
+    92% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  @keyframes seal-pile-shrink {
+    0%,
+    10% {
+      opacity: 1;
+    }
+    16%,
+    100% {
+      opacity: 0.85;
+    }
+  }
+  @keyframes seal-pile-grow {
+    0%,
+    74% {
+      transform: scaleY(0.94);
+    }
+    82%,
+    100% {
+      transform: scaleY(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .runner-seal :is(g, rect) {
+      animation: none;
+    }
+    /* Without the throw the sheet would sit mid-air at its start position. */
+    .runner-seal__sheet,
+    .runner-seal__tick {
+      display: none;
+    }
+  }
+
   /* --- editable grid ------------------------------------------------------
      The layout module lets the user drag a card by its head and resize it from
      the corner grip. Everything below is scoped to .is-editable, which the

--- a/public/css/pages/dashboard.css
+++ b/public/css/pages/dashboard.css
@@ -102,6 +102,13 @@
   .zr-grid {
     --zr-tile-row: 40px;
   }
+  /* Cards in a row end on the same line. The framework grid lets each card stop
+     at its own content, which is right for a page that mixes one-off panels;
+     a dashboard of peers reads better squared off. Scoped to this grid so the
+     styleguide's example grids keep the framework behaviour. */
+  .zr-grid[data-module='dashboard-layout'] {
+    align-items: stretch;
+  }
   .zr-module[data-rows] {
     display: flex;
     flex-direction: column;

--- a/public/css/tokens.css
+++ b/public/css/tokens.css
@@ -142,6 +142,17 @@
     --zr-shadow-sm: 0 1px 2px rgba(13, 27, 38, 0.06);
     --zr-shadow-md: 0 4px 12px -4px rgba(13, 27, 38, 0.14);
     --zr-shadow-lg: 0 16px 40px -12px rgba(13, 27, 38, 0.26);
+
+    /* The placeholder sheen, stated once. Both callers — the .zr-skeleton
+       component and the dashboard's loading state, which turns existing value
+       slots into placeholders — paint with this. The var()s inside resolve
+       against the element using it, so the dark theme needs no second copy. */
+    --zr-skeleton-bg: linear-gradient(
+      90deg,
+      var(--zr-surface-sunken) 25%,
+      color-mix(in srgb, var(--zr-line) 60%, var(--zr-surface-sunken)) 50%,
+      var(--zr-surface-sunken) 75%
+    );
   }
 
   :root[data-theme='dark'] {

--- a/public/js/modules/dashboard.js
+++ b/public/js/modules/dashboard.js
@@ -398,7 +398,19 @@ export default function dashboard(root, { toast }) {
       }
     } finally {
       statsInFlight = false;
+      settleLoading('stats');
     }
+  }
+
+  /* The page is loading until both fetches have reported back once: the figures
+     come from the stats call, the runner line from the status poll. Reporting
+     back counts either way — a failure is told by the stale banner, not by a
+     page that keeps pretending to load. Only the first pass matters; the
+     background refreshes must not blank the page out again. */
+  const firstPass = { stats: false, status: false };
+  function settleLoading(source) {
+    firstPass[source] = true;
+    if (firstPass.stats && firstPass.status) delete root.dataset.loading;
   }
 
   /* --- runner status ---------------------------------------------------- */
@@ -412,6 +424,12 @@ export default function dashboard(root, { toast }) {
     const scanButton = byId('scanButton');
     const stopButton = byId('stopScanButton');
     if (!scanButton || !stopButton) return;
+
+    // The runner card shows the seal sorting documents while a scan is on. It
+    // hangs off the same state the buttons read, so the animation can never
+    // disagree with what the buttons say.
+    const card = scanButton.closest('[data-widget="task-runner"]');
+    if (card) card.classList.toggle('is-scanning', Boolean(isScanning));
 
     // While the start request is in flight the scan button stays put and says
     // so. Swapping straight to "Stop" would claim a scan is running before the
@@ -502,6 +520,8 @@ export default function dashboard(root, { toast }) {
     } catch (error) {
       console.error('[dashboard] processing status failed', error);
       markStale('status', 'Live status lost');
+    } finally {
+      settleLoading('status');
     }
   }
 

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -4,7 +4,10 @@
 <%- include('partials/shell/head-end') %>
 <%- include('partials/shell/body-open', { pageTitle: 'Dashboard', version: typeof version !== 'undefined' ? version : '' }) %>
 
-<div data-module="dashboard" data-paperless-url="<%= typeof paperlessUrl !== 'undefined' ? paperlessUrl : '' %>">
+<!-- data-loading ships with the page so the placeholders are there from the
+     first paint, before the module has even been imported. The module drops it
+     once both the stats call and the status poll have reported back. -->
+<div data-module="dashboard" data-loading data-paperless-url="<%= typeof paperlessUrl !== 'undefined' ? paperlessUrl : '' %>">
 
     <!-- A persistent health banner is a status, not an alert. role="alert" plus
          aria-live="assertive" made the three-second poll interrupt the screen
@@ -90,6 +93,7 @@
                         <span class="zr-sm zr-faint zr-truncate" id="runnerDetail">Waiting for new documents</span>
                     </div>
                     <span class="zr-badge zr-badge--info hidden" id="currentDocId"></span>
+                    <%- include('partials/runner-seal') %>
                 </div>
 
                 <div class="zr-row zr-row--wrap zr-sm zr-muted" style="gap: var(--zr-4)">

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -67,7 +67,7 @@
          here is simply skipped. -->
     <section class="zr-grid" data-module="dashboard-layout">
         <!-- task runner -->
-        <article class="zr-module" data-widget="task-runner" data-span="8">
+        <article class="zr-module" data-widget="task-runner" data-span="12">
             <div class="zr-module__head">
                 <span class="zr-dot zr-dot--ok" id="runnerDot"></span>
                 <h2 class="zr-module__title">Task runner</h2>
@@ -109,7 +109,16 @@
             </div>
             <div class="zr-list" id="recentActivityList"></div>
         </article>
-
+        <!-- document types -->
+        <article class="zr-module" data-widget="document-types" data-span="4">
+            <div class="zr-module__head">
+                <h2 class="zr-module__title">Document types</h2>
+            </div>
+            <div class="zr-module__body zr-row zr-module__body--chart">
+                <svg class="zr-donut" id="documentTypesDonut" aria-hidden="true"></svg>
+                <div class="zr-grow zr-col zr-col--tight zr-sm" id="documentTypesLegend"></div>
+            </div>
+        </article>
         <!-- entities and rates -->
         <article class="zr-module" data-widget="entities" data-span="4">
             <div class="zr-module__head">
@@ -147,7 +156,6 @@
                 </div>
             </div>
         </article>
-
         <!-- token usage -->
         <article class="zr-module" data-widget="token-usage" data-span="4">
             <div class="zr-module__head">
@@ -168,7 +176,6 @@
                 </div>
             </div>
         </article>
-
         <!-- token distribution -->
         <article class="zr-module" data-widget="token-distribution" data-span="4">
             <div class="zr-module__head">
@@ -179,36 +186,23 @@
                 <div class="zr-barlist" id="tokenDistributionList"></div>
             </div>
         </article>
-
-        <!-- document types -->
-        <article class="zr-module" data-widget="document-types" data-span="4">
+        <!-- language mix -->
+        <article class="zr-module" data-widget="language-mix" data-span="4">
             <div class="zr-module__head">
-                <h2 class="zr-module__title">Document types</h2>
+                <h2 class="zr-module__title">Language mix</h2>
             </div>
-            <div class="zr-module__body zr-row zr-module__body--chart">
-                <svg class="zr-donut" id="documentTypesDonut" aria-hidden="true"></svg>
-                <div class="zr-grow zr-col zr-col--tight zr-sm" id="documentTypesLegend"></div>
+            <div class="zr-module__body">
+                <div class="zr-barlist" id="languageDistributionList"></div>
             </div>
         </article>
-
         <!-- processing split -->
-        <article class="zr-module" data-widget="processing-status" data-span="6">
+        <article class="zr-module" data-widget="processing-status" data-span="4">
             <div class="zr-module__head">
                 <h2 class="zr-module__title">Processing status</h2>
             </div>
             <div class="zr-module__body zr-row zr-module__body--chart">
                 <svg class="zr-donut" id="processingDonut" aria-hidden="true"></svg>
                 <div class="zr-grow zr-col zr-col--tight zr-sm" id="processingLegend"></div>
-            </div>
-        </article>
-
-        <!-- language mix -->
-        <article class="zr-module" data-widget="language-mix" data-span="6">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Language mix</h2>
-            </div>
-            <div class="zr-module__body">
-                <div class="zr-barlist" id="languageDistributionList"></div>
             </div>
         </article>
     </section>

--- a/views/partials/runner-seal.ejs
+++ b/views/partials/runner-seal.ejs
@@ -1,0 +1,80 @@
+<%#
+    The seal sorting documents, shown in the task runner while a scan is on.
+
+    Drawn from the same shapes and palette as public/mascot-animated.svg, but
+    flattened into a wide scene and stripped to what still reads at 200px: no
+    speckles, no whiskers, and no belly — at this size the face against the body
+    is the whole silhouette, and a second light shape only muddies it.
+
+    The animation lives in pages/dashboard.css, keyed off .is-scanning on the
+    card, so nothing moves when no scan is running.
+-%>
+<div class="runner-seal" aria-hidden="true">
+    <svg viewBox="0 0 200 96" role="presentation" focusable="false">
+        <!-- the pile still to be read, on the left -->
+        <g class="runner-seal__inbox">
+            <rect x="2" y="70" width="42" height="20" rx="3" fill="#C3D4E2"/>
+            <rect x="5" y="62" width="42" height="20" rx="3" fill="#D9E4EC"/>
+            <rect x="8" y="54" width="42" height="20" rx="3" fill="#FDFBF5"/>
+            <rect x="16" y="61" width="18" height="4" rx="2" fill="#C3D4E2"/>
+        </g>
+
+        <!-- the sheet in flight: it lifts off the left pile, arcs over the seal
+             and lands on the right one, carrying its fresh tag -->
+        <g class="runner-seal__sheet">
+            <rect x="-21" y="-13" width="42" height="26" rx="3" fill="#FDFBF5"/>
+            <rect x="-13" y="-6" width="19" height="5" rx="2.5" fill="#27A69A"/>
+            <rect x="-13" y="3" width="25" height="3" rx="1.5" fill="#C3D4E2"/>
+            <rect x="-13" y="9" width="16" height="3" rx="1.5" fill="#C3D4E2"/>
+        </g>
+
+        <!-- the seal -->
+        <g class="runner-seal__body">
+            <ellipse cx="100" cy="91" rx="30" ry="4" fill="#12314E" opacity="0.08"/>
+
+            <!-- tail flippers, behind the body -->
+            <g class="runner-seal__tail">
+                <path d="M 124 80 C 136 74 154 72 166 78 C 170 80 169 84 165 85
+                         C 151 87 135 85 126 82 Z" fill="#6486A6"/>
+            </g>
+
+            <path d="M 100 24 C 79 24 68 40 68 60 C 68 79 80 90 100 90
+                     C 120 90 132 79 132 60 C 132 40 121 24 100 24 Z" fill="#8FADC8"/>
+            <path d="M 100 24 C 121 24 132 40 132 60 C 132 79 120 90 100 90 Z"
+                  fill="#7495B4" opacity="0.35"/>
+
+            <!-- the flipper that does the tossing -->
+            <g class="runner-seal__flipper">
+                <path d="M 72 58 C 60 62 50 74 47 84 C 45 89 51 92 56 88
+                         C 65 80 72 68 76 60 Z" fill="#7495B4"/>
+            </g>
+
+            <g class="runner-seal__head">
+                <ellipse cx="100" cy="54" rx="21" ry="16" fill="#EAF2F8"/>
+                <g class="runner-seal__eyes">
+                    <circle cx="90" cy="46" r="5.2" fill="#12314E"/>
+                    <circle cx="110" cy="46" r="5.2" fill="#12314E"/>
+                    <circle cx="91.8" cy="43.8" r="1.9" fill="#FFFFFF"/>
+                    <circle cx="111.8" cy="43.8" r="1.9" fill="#FFFFFF"/>
+                </g>
+                <path d="M 95.5 55 Q 100 51.5 104.5 55 Q 102.5 61 100 62 Q 97.5 61 95.5 55 Z"
+                      fill="#12314E"/>
+                <ellipse cx="80" cy="57" rx="6" ry="3.4" fill="#F49B86" opacity="0.55"/>
+                <ellipse cx="120" cy="57" rx="6" ry="3.4" fill="#F49B86" opacity="0.55"/>
+            </g>
+        </g>
+
+        <!-- the sorted pile, on the right, with the tick that fires as a sheet lands -->
+        <g class="runner-seal__outbox">
+            <rect x="152" y="70" width="42" height="20" rx="3" fill="#C3D4E2"/>
+            <rect x="155" y="62" width="42" height="20" rx="3" fill="#D9E4EC"/>
+            <rect x="158" y="54" width="42" height="20" rx="3" fill="#FDFBF5"/>
+            <rect x="166" y="61" width="18" height="4" rx="2" fill="#27A69A"/>
+            <g class="runner-seal__tick">
+                <circle cx="186" cy="42" r="9" fill="#27A69A"/>
+                <path d="M 182 42 L 185 45.5 L 190.5 38.5" fill="none" stroke="#FFFFFF"
+                    stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+            </g>
+        </g>
+    </svg>
+</div>


### PR DESCRIPTION
Two follow-ups on the dashboard, on top of #284.

## The shipped layout is now the one from the screenshot

The default grid was inherited from the first draft — the task runner at eight columns with a card beside it, then a mix of four- and six-column cards. Now that the grid is arrangeable, the arrangement it ships with should be the one worth keeping: the runner across the top, then two rows of three peers.

The dashboard grid also stretches its cards, so the ones in a row end on the same line. The framework default (`align-items: start`) is right for a page mixing one-off panels; a dashboard of peers reads better squared off. Scoped to this grid, so the styleguide's example grids keep the framework behaviour.

Measured at four widths: 1440px gives one full-width runner and two rows of three equal-height cards, 1100px and 900px fold to two per row as the 1180px rule intends, 375px stacks. No horizontal scroll anywhere. Anyone with a stored layout keeps it — this changes what the page ships with, and what "Reset layout" restores.

## The page says what it is doing

Two moments looked identical to a stopped instance.

**While the figures are in flight**, the page was a grid of em dashes and empty chart boxes — the same dashes a genuinely empty instance shows. It now carries `data-loading` from the markup, so placeholders are there from the first paint, before the module has even been imported. The module drops it once *both* fetches have reported back: the figures come from the stats call, the runner line from the status poll. Reporting back counts either way, since a failure is told by the stale banner rather than by a page that keeps pretending to load.

The rules select by value class rather than by id, so a new card is covered without another rule, and they give the slots a `width` rather than a `min-width` — these sit in flex rows that would otherwise stretch a placeholder the size of a paragraph across the card. The sheen itself is `--zr-skeleton-bg` in tokens.css, shared with a new `.zr-skeleton` component, so there is one definition of what a placeholder looks like instead of two copies.

**While a scan is running**, the only sign was a line of text and a Stop button. The runner card now shows the seal from the logo working through the pile: a sheet lifts off the unread stack, arcs over her as her head follows and her flipper tosses, and lands on the sorted one as a tick fires. She is drawn from the mascot's own shapes and palette but stripped to what still reads at 200px — the belly went, because at this size a second light shape beside the face only muddies the silhouette. The scene hangs off the same state the scan buttons read, so it can never disagree with what the buttons say, and it shrinks with the card rather than vanishing from a narrow one.

Everything stands still under `prefers-reduced-motion`; the sheet and the tick hide there rather than freezing mid-air.

## Review notes

- Visual only: no API, no stored data, no change to what any figure means.
- The loading state was verified by holding it open in a browser — every slot carries the sheen at the right shape (73px bars for the KPI figures, a 92px round one for the donut, 48px for the sparkline, full-width blocks for the lists). The seal was driven through the module's own poll by making the status endpoint report a running scan, then checked enlarged to 640px to look at the drawing itself, in both themes.
- Suite: 61 passed, 6 skipped (server-dependent), 0 failed; eslint, stylelint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
