### PR TITLE
Dashboard stats cache, edit mode with a widget library, and the queue/settings UX fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,13 @@ node server.js                     # plain run
 # Tests (custom runner — plain node scripts, no jest/mocha)
 npm run test:all                   # all tests          (node scripts/run-tests.js --all)
 npm run test:list                  # list areas + tests
-npm run test:area:security         # run an area (auth|ocr|observability|processing|prompts|security)
+npm run test:area:security         # an area (auth|ocr|observability|processing|prompts|quickstart|security)
 node scripts/run-tests.js --test ssrf-url-validation   # single test by name
 
 # Lint / format
 npx eslint .                       # flat config: eslint.config.mjs
 npx prettier --check .             # .prettierrc.json + .prettierignore
+npm run lint:css                   # stylelint over public/css/**/*.css
 
 # Production (what Docker runs)
 pm2-runtime ecosystem.config.js    # via start-services.sh
@@ -84,6 +85,37 @@ cleans up records for documents deleted in Paperless-ngx.
 **Routes:** `routes/auth.js` (JWT-in-cookie + `x-api-key` auth, `isAuthenticated` middleware) and
 `routes/setup.js` (setup wizard + history/api endpoints). `schemas.js` holds shared swagger schemas.
 
+### UI layer ("zr")
+
+There is no frontend framework and no build step — `public/` is served as written. What replaced
+Tailwind/FontAwesome is a small in-house system whose rules are not obvious from any single file:
+
+**CSS cascade layers are the whole design.** `public/css/tokens.css` opens with the order —
+`@layer tokens, base, shell, components, modules, pages, utilities` — and every rule in every file
+sits in one of them. A later layer beats an earlier one _regardless of specificity_, so a component
+overrides a base primitive with a plain single-class selector, `pages/*.css` beats the framework, and
+the colour utilities beat everything. Two consequences worth knowing before editing: a rule written
+in the wrong file silently loses (or wins) no matter how specific it is, and every file must stay
+layered — one unlayered rule would outrank the lot. Only two link positions in `head-start.ejs` are
+load-bearing: tokens.css first, and buttons.css before forms.css.
+
+**Page behaviour is one ES module per job.** `public/js/zr.js` is the kernel: theme, drawer, rail,
+active nav, the toast, and a registry that imports `public/js/modules/<name>.js` for each
+`data-module="<name>"` it finds. A page therefore costs its own modules and nothing else. Classic
+scripts (`public/js/*.js`) cannot import ES modules — they reach the kernel through
+`window.__zrToast` / `window.zrDialog` (see `failed.js` for the six-line adapter) and must never
+build their own toast host.
+
+**Conventions that bite if missed:** icons are `<symbol>`s in `public/icons.svg`, referenced with
+`<use href="/icons.svg#i-name">` — there is no icon font, so `querySelector('i')` finds nothing;
+`.hidden` is a deliberate `!important` class that JS toggles ~100×; `/styleguide` (dev builds only,
+authenticated) renders every component once and is the place to check before inventing a class.
+
+**Verifying UI work:** the app cannot be opened without a database and a Paperless-ngx instance, so
+UI changes are reviewed with a throwaway Express server that renders the EJS views with mock locals
+and mock API endpoints. Review list pages _with rows_ — a migration bug once hid in the queue tables
+because they were only ever looked at empty.
+
 ### Document processing flow (the core loop in server.js)
 
 1. `node-cron` fires on `config.scanInterval` (cron syntax, default `*/30 * * * *`).
@@ -112,9 +144,10 @@ config object you set in code; everything is an env var.**
 
 ## CI
 
-Every PR runs `.github/workflows/ci.yml`: ESLint + Prettier on the **files changed in the PR**
-(the legacy codebase is not fully clean yet — anything you touch must pass), the offline test suite
-(`node scripts/run-tests.js --all`), and an OpenAPI drift check (`regen-openapi.js` + `git diff`).
+Every PR runs `.github/workflows/ci.yml`: ESLint, Prettier and stylelint on the **files changed in
+the PR** (the legacy codebase is not fully clean yet — anything you touch must pass), the offline
+test suite (`node scripts/run-tests.js --all`), and an OpenAPI drift check
+(`regen-openapi.js` + `git diff`).
 PRs touching Docker/dependency manifests additionally trigger `docker-check.yml` (build-only).
 `security-audit.yml` runs `npm audit` weekly on a schedule.
 
@@ -134,6 +167,9 @@ PRs touching Docker/dependency manifests additionally trigger `docker-check.yml`
 - **API responses:** `{ success: true, data, message }` / `{ success: false, error }`.
 - **SSE:** set `X-Accel-Buffering: no` and call `res.flush()` after each `res.write(...)`.
 - **DataTables endpoints** expect `{ data, recordsTotal, recordsFiltered }`.
+- **Stylelint guards the stylesheets:** duplicate selectors, duplicate properties and unquoted font
+  names fail the build. The duplicate check scopes per `@layer` block, so keep one layer block per
+  file. `no-descending-specificity` is off — it is structurally at odds with cascade layers.
 
 ## Docs
 

--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -3480,7 +3480,7 @@
     "/api/dashboard/stats": {
       "get": {
         "summary": "Get dashboard statistics payload",
-        "description": "Returns all aggregate counters and chart datasets required by the dashboard UI.",
+        "description": "Returns all aggregate counters and chart datasets required by the dashboard UI.\n\nThe payload is served from an in-memory cache instead of being rebuilt per\nrequest. It is refreshed in the background (once a minute, plus after every\nscan run) and expires after STATS_CACHE_TTL_SECONDS (default 60). The scan\nloop invalidates it for every document it processes, so figures follow\nprocessing without polling Paperless-ngx on every request.\n",
         "tags": [
           "System",
           "API"
@@ -3499,7 +3499,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "cachedAt": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Epoch milliseconds at which the returned payload was assembled. 0 when the assembly time is unknown."
+                    },
+                    "paperless_data": {
+                      "type": "object",
+                      "description": "Aggregate counters and chart datasets."
+                    },
+                    "openai_data": {
+                      "type": "object",
+                      "description": "Token averages and the overall token total."
+                    }
+                  }
                 }
               }
             }

--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -5401,8 +5401,8 @@
     },
     "/api/dashboard/layout": {
       "get": {
-        "summary": "Read the authenticated user's dashboard grid layout",
-        "description": "Returns the widget order, column spans and tile-row heights the user arranged. widgets is empty when the user has not customised anything, which means the dashboard renders in its default order.\n",
+        "summary": "Read the authenticated user's dashboard configuration",
+        "description": "Returns the stored configuration in storage format v1: the named dashboards the user arranged, each with its widgets in display order, and the slug of the active one. An empty dashboards list means nothing has been customised and every board renders in its default order — the same answer a user without a stored configuration gets.\n",
         "tags": [
           "Dashboard"
         ],
@@ -5413,7 +5413,84 @@
         ],
         "responses": {
           "200": {
-            "description": "The stored layout"
+            "description": "The stored configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Slug of the dashboard currently shown",
+                          "example": "default"
+                        },
+                        "dashboards": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "slug": {
+                                "type": "string",
+                                "example": "default"
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Dashboard"
+                              },
+                              "widgets": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "example": "task-runner"
+                                    },
+                                    "span": {
+                                      "type": "integer",
+                                      "description": "Width in grid columns, 3 to 12",
+                                      "example": 12
+                                    },
+                                    "rows": {
+                                      "type": "integer",
+                                      "description": "Height in tile rows, 3 to 24, or 0 for as tall as the content",
+                                      "example": 0
+                                    },
+                                    "hidden": {
+                                      "type": "boolean",
+                                      "example": false
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "widgets": {
+                          "type": "array",
+                          "deprecated": true,
+                          "description": "Deprecated alias for the active dashboard's widgets, kept only until the browser module speaks the named-dashboard format. Read dashboards instead.\n",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
             "description": "Not authenticated"
@@ -5421,8 +5498,8 @@
         }
       },
       "put": {
-        "summary": "Store or reset the authenticated user's dashboard grid layout",
-        "description": "Accepts a widgets array of {id, span, rows} in display order. Spans are 3 to 12 grid columns; rows are 3 to 24 tile rows, or 0 for a card that is as tall as its content. Sending an empty widgets array clears the layout, so the dashboard returns to its default order.\n",
+        "summary": "Store or reset the authenticated user's dashboard configuration",
+        "description": "Takes a complete configuration in storage format v1 and replaces the stored one; there is no partial update. Up to 10 dashboards, each with a slug, a name of 1 to 60 characters and up to 50 widgets in display order. Widget spans are 3 to 12 grid columns; rows are 3 to 24 tile rows, or 0 for a card that is as tall as its content. A dashboard without widgets shows the default arrangement under its own name.\nTwo payloads reset instead of storing: an empty dashboards array, and a single dashboard whose widgets array is empty. Both clear the stored configuration, so every board returns to its default order. Emptying one board out of several does not reset — that board simply shows the defaults and keeps its name.\nIf active names a dashboard that is not in the payload it is replaced with the first dashboard's slug rather than rejecting the write.\nDeprecated: a flat {widgets: [...]} body is still accepted and stored as the single 'default' dashboard, until the browser module speaks the named-dashboard format. Do not build on it.\n",
         "tags": [
           "Dashboard"
         ],
@@ -5431,12 +5508,93 @@
             "BearerAuth": []
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "integer",
+                    "enum": [
+                      1
+                    ],
+                    "example": 1
+                  },
+                  "active": {
+                    "type": "string",
+                    "description": "Slug of the dashboard to show",
+                    "example": "default"
+                  },
+                  "dashboards": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "slug",
+                        "name"
+                      ],
+                      "properties": {
+                        "slug": {
+                          "type": "string",
+                          "pattern": "^[a-z0-9][a-z0-9-]{0,39}$",
+                          "example": "default"
+                        },
+                        "name": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 60,
+                          "example": "Dashboard"
+                        },
+                        "widgets": {
+                          "type": "array",
+                          "maxItems": 50,
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "id",
+                              "span"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "pattern": "^[a-z0-9][a-z0-9-]{0,39}$",
+                                "example": "task-runner"
+                              },
+                              "span": {
+                                "type": "integer",
+                                "minimum": 3,
+                                "maximum": 12,
+                                "example": 12
+                              },
+                              "rows": {
+                                "type": "integer",
+                                "description": "3 to 24 tile rows, or 0 for as tall as the content",
+                                "example": 0
+                              },
+                              "hidden": {
+                                "type": "boolean",
+                                "default": false
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Layout stored"
+            "description": "Configuration stored or reset"
           },
           "400": {
-            "description": "Malformed layout"
+            "description": "Malformed configuration"
           },
           "401": {
             "description": "Not authenticated"

--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -5476,14 +5476,6 @@
                               }
                             }
                           }
-                        },
-                        "widgets": {
-                          "type": "array",
-                          "deprecated": true,
-                          "description": "Deprecated alias for the active dashboard's widgets, kept only until the browser module speaks the named-dashboard format. Read dashboards instead.\n",
-                          "items": {
-                            "type": "object"
-                          }
                         }
                       }
                     }
@@ -5499,7 +5491,7 @@
       },
       "put": {
         "summary": "Store or reset the authenticated user's dashboard configuration",
-        "description": "Takes a complete configuration in storage format v1 and replaces the stored one; there is no partial update. Up to 10 dashboards, each with a slug, a name of 1 to 60 characters and up to 50 widgets in display order. Widget spans are 3 to 12 grid columns; rows are 3 to 24 tile rows, or 0 for a card that is as tall as its content. A dashboard without widgets shows the default arrangement under its own name.\nTwo payloads reset instead of storing: an empty dashboards array, and a single dashboard whose widgets array is empty. Both clear the stored configuration, so every board returns to its default order. Emptying one board out of several does not reset — that board simply shows the defaults and keeps its name.\nIf active names a dashboard that is not in the payload it is replaced with the first dashboard's slug rather than rejecting the write.\nDeprecated: a flat {widgets: [...]} body is still accepted and stored as the single 'default' dashboard, until the browser module speaks the named-dashboard format. Do not build on it.\n",
+        "description": "Takes a complete configuration in storage format v1 and replaces the stored one; there is no partial update. Up to 10 dashboards, each with a slug, a name of 1 to 60 characters and up to 50 widgets in display order. Widget spans are 3 to 12 grid columns; rows are 3 to 24 tile rows, or 0 for a card that is as tall as its content. A dashboard without widgets shows the default arrangement under its own name.\nTwo payloads reset instead of storing: an empty dashboards array, and a single dashboard whose widgets array is empty. Both clear the stored configuration, so every board returns to its default order. Emptying one board out of several does not reset — that board simply shows the defaults and keeps its name.\nIf active names a dashboard that is not in the payload it is replaced with the first dashboard's slug rather than rejecting the write.\n",
         "tags": [
           "Dashboard"
         ],

--- a/config/config.js
+++ b/config/config.js
@@ -522,6 +522,12 @@ module.exports = {
   // Cache configuration (in seconds)
   // Recommended: 300 (5 min) for balanced performance, 60-900 (1-15 min) for custom needs
   tagCacheTTL: parseInt(process.env.TAG_CACHE_TTL_SECONDS || '300', 10),
+  // How long the assembled dashboard statistics payload stays valid. The
+  // dashboard polls its stats endpoint, so without this every poll of every
+  // open tab paid for two Paperless-ngx round trips and a dozen queries. The
+  // scan loop invalidates the cache as it processes documents, so a low value
+  // buys little beyond faster reaction to changes made outside this app.
+  statsCacheTTL: parseInt(process.env.STATS_CACHE_TTL_SECONDS || '60', 10),
   // Add limit functions to config
   limitFunctions: {
     activateTagging: limitFunctions.activateTagging,

--- a/config/dashboardWidgets.js
+++ b/config/dashboardWidgets.js
@@ -1,0 +1,22 @@
+/**
+ * The dashboard cards, in the order they are rendered when nobody has
+ * rearranged anything.
+ *
+ * Adding a widget is two steps: drop one partial into views/partials/widgets/
+ * named after its id, and add one entry here. The route hands this list to
+ * views/dashboard.ejs, which includes each partial and passes it its entry, so
+ * the span lives here and nowhere else.
+ *
+ * The display title deliberately stays out of this file: it is already in the
+ * partial's .zr-module__title, and the edit tray reads it from the DOM. Two
+ * places for one string is one place too many — they drift.
+ */
+module.exports = [
+  { id: 'task-runner', span: 12 },
+  { id: 'document-types', span: 4 },
+  { id: 'entities', span: 4 },
+  { id: 'token-usage', span: 4 },
+  { id: 'token-distribution', span: 4 },
+  { id: 'language-mix', span: 4 },
+  { id: 'processing-status', span: 4 },
+];

--- a/models/document.js
+++ b/models/document.js
@@ -100,6 +100,26 @@ const insertMetrics = db.prepare(`
   VALUES (?, ?, ?, ?)
 `);
 
+// The dashboard only needs the aggregates, never the rows. COALESCE keeps rows
+// with a missing token count in the denominator, which is what the previous
+// JavaScript reduce did when it added `undefined` as 0.
+const selectMetricsSummary = db.prepare(`
+  SELECT
+    COUNT(*) as sampleCount,
+    AVG(COALESCE(promptTokens, 0)) as avgPromptTokens,
+    AVG(COALESCE(completionTokens, 0)) as avgCompletionTokens,
+    AVG(COALESCE(totalTokens, 0)) as avgTotalTokens,
+    COALESCE(SUM(COALESCE(totalTokens, 0)), 0) as totalTokensOverall
+  FROM openai_metrics
+`);
+
+const emptyMetricsSummary = () => ({
+  averagePromptTokens: 0,
+  averageCompletionTokens: 0,
+  averageTotalTokens: 0,
+  tokensOverall: 0,
+});
+
 const insertUser = db.prepare(`
   INSERT INTO users (username, password)
   VALUES (?, ?)
@@ -411,12 +431,31 @@ module.exports = {
     }
   },
 
-  async getMetrics() {
+  /**
+   * Token averages and the overall total, aggregated by SQLite.
+   *
+   * Replaces `getMetrics()`, which materialized every openai_metrics row just
+   * so the dashboard could reduce over it four times. The table grows with
+   * every processed document; these four numbers do not.
+   */
+  async getMetricsSummary() {
     try {
-      return db.prepare('SELECT * FROM openai_metrics').all();
+      const row = selectMetricsSummary.get();
+      if (!row || !row.sampleCount) {
+        return emptyMetricsSummary();
+      }
+
+      return {
+        // Rounded here rather than in SQL so the values stay bit-for-bit what
+        // Math.round() produced before.
+        averagePromptTokens: Math.round(row.avgPromptTokens || 0),
+        averageCompletionTokens: Math.round(row.avgCompletionTokens || 0),
+        averageTotalTokens: Math.round(row.avgTotalTokens || 0),
+        tokensOverall: Number(row.totalTokensOverall || 0),
+      };
     } catch (error) {
-      console.error('[ERROR] getting metrics:', error);
-      return [];
+      console.error('[ERROR] getting metrics summary:', error);
+      return emptyMetricsSummary();
     }
   },
 

--- a/public/css/forms.css
+++ b/public/css/forms.css
@@ -197,6 +197,29 @@
     color: var(--zr-text-faint);
     cursor: not-allowed;
   }
+  /* A value the page only reports, wearing the input box so it lines up with the
+     button beside it — the detected public URL. It looked exactly like an
+     editable field, down to the white fill and the text cursor. Unlike a
+     disabled input it is not a control that was switched off, so it keeps the
+     normal text colour and grows with its content instead of clipping: these
+     values are long and there is no caret to scroll them with. */
+  .zr-input--static {
+    height: auto;
+    min-height: 30px;
+    /* The other controls centre their text with the fixed height alone; this one
+       wraps, so the air has to be padding. */
+    padding-block: 5px;
+    background: var(--zr-surface-2);
+    word-break: break-all;
+    cursor: default;
+  }
+  /* Stated even though the plain div cannot be focused: a static value that is
+     made focusable to be copied — as the API key box next to it is — would
+     otherwise light up the brand ring and promise an editable field. */
+  .zr-input--static:focus {
+    border-color: var(--zr-line-strong);
+    box-shadow: none;
+  }
   .zr-inputgroup {
     display: flex;
     gap: var(--zr-2);
@@ -377,8 +400,18 @@
 
   /* masked API key field */
   .zr-apikey {
-    display: flex;
-    align-items: center;
+    /* A block, not a flex box. The key is a bare text node, and in a flex
+       container that becomes an anonymous item which text-overflow cannot reach
+       (the property is not inherited, so the item keeps `clip`) — a 64-character
+       key painted straight through the border and across the button next to it.
+       The line height does the vertical centring the flex box used to do: the
+       control is 30px tall and 1px of that is border on either side. */
+    display: block;
+    line-height: 28px;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     cursor: pointer;
     filter: blur(4px);
     transition: filter var(--zr-dur) var(--zr-ease);
@@ -431,6 +464,16 @@
     .zr-select,
     .zr-btn {
       height: 38px; /* touch target */
+    }
+    /* …which a reported value is not: it is nothing to tap, and a fixed height
+       would cut off the wrapped lines it exists to show. */
+    .zr-input--static {
+      height: auto;
+    }
+    /* The key box is tappable — it copies — so it keeps the taller target, and
+       the line height that centres its single line has to follow. */
+    .zr-apikey {
+      line-height: 36px;
     }
   }
 }

--- a/public/css/pages/dashboard.css
+++ b/public/css/pages/dashboard.css
@@ -274,18 +274,50 @@
     }
   }
 
-  /* --- editable grid ------------------------------------------------------
-     The layout module lets the user drag a card by its head and resize it from
-     the corner grip. Everything below is scoped to .is-editable, which the
-     module only sets on wide viewports — the phone grid is one column, so
-     there is nothing to arrange there. */
+  /* --- edit mode ----------------------------------------------------------
+     The dashboard is view-only until the user opens an edit session. The layout
+     module then puts .is-editing on the grid, and every affordance that lets a
+     card be moved, resized or switched off hangs off that one class: outside
+     the session there is no grip, no grab cursor and no drag, so a card is just
+     a card and a click on it does what it says.
+
+     .is-sortable is the narrower flag on top of it — the module sets it only
+     once the vendor drag script is really attached, so the grab cursor never
+     promises a drag that cannot happen. It is only ever set inside a session.
+
+     Editing is desktop-only. Below 861px the grid is a single column and every
+     card spans the full width, so the module never opens a session there; the
+     media query at the end of this file takes the bars and the grips off the
+     page as well, so that holds even if the module were never told. */
 
   .zr-layoutbar {
     justify-content: flex-end;
     margin-bottom: var(--zr-2);
   }
 
-  .zr-grid.is-editable > [data-widget] {
+  /* --- the edit tray ------------------------------------------------------
+     Rendered above the grid and unhidden for the session: one chip per card on
+     the left, reset, cancel and done on the right. */
+  .zr-editbar {
+    margin-bottom: var(--zr-3);
+  }
+  .zr-editbar__actions {
+    margin-left: auto;
+  }
+  /* The chip carries its own state: pressed is a card that is on the dashboard
+     and reads normally, unpressed is one that is not and steps back with its
+     label struck through. Two cues rather than a colour, because a colour alone
+     would leave the states indistinguishable to some readers — and because the
+     chips sit next to each other, where a faint one is only obvious in
+     comparison. */
+  .zr-editbar__chip[aria-pressed='false'] {
+    opacity: 0.5;
+  }
+  .zr-editbar__chip[aria-pressed='false'] span {
+    text-decoration: line-through;
+  }
+
+  .zr-grid.is-editing > [data-widget] {
     position: relative;
   }
   /* The head doubles as the drag handle, so it has to say so — but only where
@@ -323,7 +355,11 @@
     border-bottom: 2px solid currentcolor;
     border-bottom-right-radius: 3px;
   }
-  .zr-grid:not(.is-editable) .zr-module__grip {
+  /* The grips are in the markup from the moment the module mounts; only the
+     session puts them on screen. display: none also keeps them out of the tab
+     order, which is what makes the keyboard resize path a part of the session
+     rather than a surprise on a page nobody is editing. */
+  .zr-grid:not(.is-editing) .zr-module__grip {
     display: none;
   }
   [data-widget]:hover > .zr-module__grip,
@@ -350,6 +386,29 @@
   }
   .zr-module.is-dragghost {
     opacity: 0.35;
+  }
+
+  /* --- cards the user switched off ----------------------------------------
+     A hidden card keeps its markup and its module instance — the dashboard goes
+     on writing numbers into it — so only these two rules decide whether it is
+     on screen, and they say opposite things on purpose:
+
+     - while reading, the card is not there at all;
+     - while editing, it stays in the grid, faded and outlined, because a card
+       you cannot see is a card you cannot drag to where you want it, and
+       switching it back on has to be possible from the same place.
+
+     The hiding is written as :not(.is-editing) rather than as a display value
+     the session overrides: a card that was given a tile height carries
+     display: flex from the tiles block below, and re-stating a display here
+     would have to guess which one to put back. */
+  .zr-grid:not(.is-editing) > .zr-module.is-hidden {
+    display: none;
+  }
+  .zr-grid.is-editing > .zr-module.is-hidden {
+    opacity: 0.35;
+    outline: 1px dashed var(--zr-line-strong);
+    outline-offset: -1px;
   }
 
   /* --- tiles --------------------------------------------------------------
@@ -430,6 +489,22 @@
   }
 
   @media (max-width: 860px) {
+    /* Neither bar has anything to offer on a phone: one column leaves nothing
+       to arrange, so the module never opens a session here. It hides its own
+       button as well — this is the guard that keeps an empty bar from taking up
+       a line if it ever did not. */
+    .zr-layoutbar,
+    .zr-editbar {
+      display: none;
+    }
+    /* And the grips go with them, which makes "no editing here" true from the
+       stylesheet alone: a viewport that reaches this width without the module
+       hearing about it still cannot offer a resize the single column could not
+       honour. */
+    .zr-module__grip {
+      display: none;
+    }
+
     /* One column, full width: a stored tile height would only cut content off
        or leave a gap, so it stands down here. */
     .zr-module[data-rows] {

--- a/public/css/pages/settings.css
+++ b/public/css/pages/settings.css
@@ -23,6 +23,92 @@
 
   /* --- settings ------------------------------------------------------------ */
 
+  /* The section nav navigates with plain #hash links, and the browser scrolls the
+     target flush to the top of the viewport — where the sticky topbar sits on top
+     of it. Every landing target gets the topbar plus the gap the section nav
+     itself keeps below it, so a section lands where the nav says it is.
+     js/modules/section-nav.js approximates the same offset for the scroll-spy. */
+  .zr-settings :is([id$='-tab'], .zr-module[id^='sec-']) {
+    scroll-margin-top: calc(var(--zr-topbar-h) + var(--zr-4));
+  }
+
+  /* Sixty-odd settings rows separated by nothing but 16px of air read as one
+     wall of controls: nothing says where a setting starts or ends. Rows get what
+     rows get everywhere else in the app — a hairline between them and a hover
+     band — drawn the way .zr-table draws them, from card edge to card edge, which
+     the body's own padding has to be undone for.
+
+     Scoped to a card's own body: #changelog-tab uses .zr-module__body as a bare
+     layout wrapper outside any .zr-module, where the release timeline brings its
+     own rhythm and there is no card box for a full-bleed band to bleed into. */
+  .zr-settings .zr-module > .zr-module__body.zr-col--loose {
+    gap: 0;
+  }
+  /* With the gap gone the rows space themselves, and they ask whether anything is
+     rendered above them with the general sibling combinator rather than the
+     adjacent one: half of this form is toggled with .hidden and the custom-field
+     list is an empty box until a field is added, so the row below one of those
+     would otherwise be spaced and ruled off against nothing. */
+  .zr-settings
+    .zr-module
+    > .zr-module__body.zr-col--loose
+    > *:not(.hidden, #customFieldsList:not(:has(*)))
+    ~ * {
+    margin-top: var(--zr-4);
+  }
+  /* A switch tile, an alert or a lone button draws a box of its own, which makes
+     it the exception to both rules below: it keeps the spacing the gap used to
+     give it, and it never carries a hairline — the line would run along its own
+     border, and the padding that comes with the line would push its content off
+     centre. One switch row is wrapped in a field instead of coming from the
+     partial, which is what the :has() catches. */
+  .zr-settings
+    .zr-module
+    > .zr-module__body.zr-col--loose
+    > *:not(.zr-switchrow, .zr-alert, .zr-btn, :has(> .zr-switchrow)) {
+    /* The inset is part of the row at rest, not only under the pointer: added on
+       hover, every row would shift sideways as its band appears. */
+    margin-inline: calc(var(--zr-3) * -1);
+    padding-inline: var(--zr-3);
+  }
+  .zr-settings
+    .zr-module
+    > .zr-module__body.zr-col--loose
+    > *:not(.hidden, #customFieldsList:not(:has(*)))
+    ~ *:not(.zr-switchrow, .zr-alert, .zr-btn, :has(> .zr-switchrow)) {
+    border-top: 1px solid var(--zr-line);
+    padding-top: var(--zr-3);
+    margin-top: var(--zr-3);
+  }
+
+  /* The OCR block is a whole list of settings inside one .zr-field, so its rows
+     are not the body's rows and none of the above reaches them — they were left
+     5px apart, the spacing meant for a label and its input. They at least get the
+     air the body gives its own rows. */
+  .zr-settings .zr-module__body > .zr-field--stacked:has(.zr-field--stacked) {
+    gap: var(--zr-4);
+  }
+
+  /* Only the fields light up: a hint or a heading is nothing to point at. A field
+     holding other fields is a wrapper rather than a row — #ocrFieldsContainer is
+     a .zr-field around the entire OCR block, and lighting that up would paint
+     half the card. */
+  .zr-settings
+    .zr-module
+    > .zr-module__body.zr-col--loose
+    > .zr-field--stacked:not(:has(.zr-field--stacked, .zr-switchrow)):hover {
+    background: var(--zr-surface-2);
+  }
+  /* The unsaved-change marker hangs one body padding to the left of its field —
+     which, measured from a full-bleed row, is outside the card, where the
+     module's overflow: hidden eats it. Zero puts it back on the same pixel. */
+  .zr-settings
+    .zr-module
+    > .zr-module__body.zr-col--loose
+    > .zr-field[data-dirty]:not(:has(> .zr-switchrow))::before {
+    left: 0;
+  }
+
   /* The "field name + type + Add" row: its controls sit in wrapper divs (a bare
      width:100% control would hijack the whole flex row), so the generic
      full-width phone rule cannot reach them. Stack the wrappers instead. */

--- a/public/css/pages/shared.css
+++ b/public/css/pages/shared.css
@@ -20,12 +20,90 @@
     gap: 0.5rem;
   }
 
+  /* The field and its dropdown, boxed together: the panel is pinned to this
+     box's edges, so it always ends up exactly as wide as the field, and it can
+     no longer become a flex item of the row it sits in — inside the OCR
+     toolbar the panel used to line up beside the field as a third control. */
+  .manual-search-anchor {
+    position: relative;
+    /* Flex rather than block: an inline-block input in a block leaves the
+       line-box descender under it, and the panel hangs off the box bottom. */
+    display: flex;
+    /* forms.css caps a lone .zr-input at 460px. The cap has to sit on the
+       anchor instead, or the panel would be wider than the field it belongs
+       to; the field then fills the anchor. */
+    max-width: 460px;
+  }
+
+  .manual-search-anchor .zr-input {
+    flex: 1;
+    min-width: 0;
+    max-width: none;
+  }
+
+  /* The results are a dropdown over the page, not a block in the flow: in the
+     flow they pushed the manual form down on every keystroke and squeezed
+     themselves into the OCR toolbar line.
+     z-index clears the sticky action bar (15) and stays under the drawer scrim
+     (40), the rail (50) and the toasts (60). */
   .manual-search-results {
-    max-height: 260px;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 30;
+    max-height: 320px;
     overflow-y: auto;
     border: 1px solid var(--zr-line);
-    border-radius: 0.375rem;
+    border-radius: var(--zr-r-md);
     background: var(--zr-surface);
+    box-shadow: var(--zr-shadow-lg);
+  }
+
+  /* A .zr-module clips its content (overflow: hidden) and, through
+     container-type: inline-size, is a stacking context of its own — so a panel
+     leaving the module would be cut off at its edge and painted below the next
+     module whatever z-index it carries. The module hosting a search field opts
+     out of the clip and takes a z-index of its own, which is what lifts the
+     panel over everything below it. */
+  .zr-module:has(.manual-search-anchor) {
+    position: relative;
+    z-index: 1;
+    overflow: visible;
+  }
+
+  /* One result row. It is a <button>, so the base reset already took the UA
+     background, border and cursor off it; what is left is the block layout the
+     stacked title and pill rows need and the left alignment a button does not
+     have by default. */
+  .manual-search-item {
+    display: block;
+    width: 100%;
+    padding: var(--zr-2) var(--zr-3);
+    text-align: left;
+    color: inherit;
+    border-bottom: 1px solid var(--zr-line);
+  }
+
+  .manual-search-item:last-child {
+    border-bottom: 0;
+  }
+
+  /* The reset zeroes every margin, so the pill rows would touch the title. */
+  .manual-search-item > * + * {
+    margin-top: 4px;
+  }
+
+  /* Pointer and keyboard share one highlight. document-omnibox.js marks the
+     ArrowUp/ArrowDown row with .active and leaves its aria-selected at "false",
+     so the class is what carries the state. */
+  .manual-search-item:hover,
+  .manual-search-item.active {
+    background: var(--zr-surface-2);
+  }
+
+  .manual-search-title {
+    font-weight: 500;
   }
 
   .manual-search-meta {
@@ -241,7 +319,10 @@
     flex: 1 1 320px;
     min-width: 220px;
   }
-  .app-toolbar .manual-search-wrapper .zr-input {
+  /* The field sits in its anchor now, so the row's free space goes to the
+     anchor — and the toolbar is wide enough that keeping the 460px field cap
+     would only leave a hole at the end of the row. */
+  .app-toolbar .manual-search-anchor {
     flex: 1;
     min-width: 0;
     max-width: none;

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -269,6 +269,10 @@ class HistoryManager {
           render: (value, row) => {
             const docId = escape(row.document_id ?? value);
             const menuId = `historyRowMenu${docId}`;
+            // _esc(), not escape(): the innerHTML round-trip behind escape()
+            // leaves a double quote intact, and a Paperless-ngx title is free
+            // text that would otherwise break out of the attribute.
+            const titleAttr = this._esc(row.title ?? '');
             return (
               '<div class="zr-row zr-row--wrap">' +
               `<button type="button" class="history-info-btn zr-btn" data-docid="${escape(value)}" title="Show AI analysis details">` +
@@ -283,6 +287,13 @@ class HistoryManager {
               '<div class="zr-menu__sep"></div>' +
               `<button type="button" class="zr-menu__item history-ocr-btn" data-docid="${docId}">` +
               '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-scan"/></svg>Send to OCR queue</button>' +
+              `<button type="button" class="zr-menu__item history-rescan-btn" data-docid="${docId}">` +
+              '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-refresh"/></svg>Reanalyze</button>' +
+              '<div class="zr-menu__sep"></div>' +
+              // Last and set apart: it is the only entry here that takes the
+              // document out of future scans rather than feeding one.
+              `<button type="button" class="zr-menu__item zr-menu__item--danger history-ignore-btn" data-docid="${docId}" data-title="${titleAttr}">` +
+              '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-eye-off"/></svg>Ignore</button>' +
               '</div>' +
               '</div>'
             );
@@ -512,6 +523,34 @@ class HistoryManager {
       });
       button.dataset.boundClick = 'true';
     });
+
+    document.querySelectorAll('.history-rescan-btn').forEach((button) => {
+      if (button.dataset.boundClick === 'true') return;
+      button.addEventListener('click', () => {
+        const docId = button.dataset.docid || '';
+        if (!/^\d+$/.test(docId)) {
+          console.warn('Blocked unsafe document id:', docId);
+          return;
+        }
+        this.rescanFromRow(Number(docId));
+      });
+      button.dataset.boundClick = 'true';
+    });
+
+    document.querySelectorAll('.history-ignore-btn').forEach((button) => {
+      if (button.dataset.boundClick === 'true') return;
+      button.addEventListener('click', () => {
+        const docId = button.dataset.docid || '';
+        if (!/^\d+$/.test(docId)) {
+          console.warn('Blocked unsafe document id:', docId);
+          return;
+        }
+        // The title travels in the markup because the ignore list stores it and
+        // the row is the only place that still knows it at click time.
+        this.ignoreDocument(Number(docId), button.dataset.title || '');
+      });
+      button.dataset.boundClick = 'true';
+    });
   }
 
   /**
@@ -550,6 +589,51 @@ class HistoryManager {
     }
 
     this.showToast(message, tone);
+  }
+
+  /**
+   * Puts a document on the ignore list, so the scan loop leaves it alone from
+   * now on. The Ignored page is otherwise the only way in, and it wants a
+   * document id typed by hand — from here the row already knows it. Reversible
+   * there via "Unignore".
+   */
+  async ignoreDocument(documentId, title) {
+    let message;
+    let tone = 'success';
+
+    // Same split as sendToOcrQueue(): the request stands alone so a fault while
+    // reporting the outcome cannot be shown as a failure to ignore.
+    try {
+      const response = await fetch('/api/ignored/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          documentId,
+          // The list shows the title next to the id; without it the entry would
+          // be a bare number nobody can place later.
+          title: title || '',
+          reason: 'manual',
+        }),
+      });
+      const data = await response.json();
+
+      if (data.success) {
+        message =
+          data.message || `Document ${documentId} added to the ignore list.`;
+      } else {
+        message =
+          data.message || data.error || 'Could not ignore the document.';
+        tone = 'error';
+      }
+    } catch (error) {
+      message = `Could not ignore the document: ${error.message}`;
+      tone = 'error';
+    }
+
+    this.showToast(message, tone);
+    if (tone === 'success') {
+      this.table?.reload();
+    }
   }
 
   isSafeHistoryLink(link) {
@@ -942,7 +1026,7 @@ class HistoryManager {
 
       this.hideModal(document.getElementById('infoModal'));
       this.showToast('Document restored to its original state.', 'success');
-      this.table?.ajax.reload();
+      this.table?.reload();
     } catch (err) {
       console.error('Restore failed:', err);
       this.showToast('Restore failed: ' + err.message, 'error');
@@ -995,6 +1079,32 @@ class HistoryManager {
     }
   }
 
+  /**
+   * Sends one document back for reprocessing and returns the parsed response.
+   * Only the request is shared: the modal button and the row menu differ in
+   * what they have to put back afterwards (a spinner, a modal), and the row
+   * menu has neither. Throws on anything the caller should report as a failure.
+   */
+  async postRescan(documentId) {
+    // Reprocess directly, bypassing the scan tag filter. The backend clears the
+    // local record and enqueues the document for processing.
+    const response = await fetch(`/api/history/${documentId}/rescan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`Rescan request failed (${response.status})`);
+    }
+
+    // A JSON body is part of the contract, so an expired session answered with
+    // the login page throws here instead of passing for a queued document.
+    const data = await response.json();
+    if (data && data.success === false) {
+      throw new Error(data.error || 'Rescan failed');
+    }
+    return data;
+  }
+
   async rescanDocument(documentId) {
     const btn = document.getElementById('infoModalRescanBtn');
     const origHtml = btn?.innerHTML;
@@ -1005,13 +1115,7 @@ class HistoryManager {
     }
 
     try {
-      // Reprocess directly, bypassing the scan tag filter. The backend
-      // clears the local record and enqueues the document for processing.
-      const resetRes = await fetch(`/api/history/${documentId}/rescan`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (!resetRes.ok) throw new Error('Reset failed');
+      await this.postRescan(documentId);
 
       // Close modal & show toast
       this.hideModal(document.getElementById('infoModal'));
@@ -1021,7 +1125,7 @@ class HistoryManager {
       );
 
       // Reload table
-      this.table?.ajax.reload();
+      this.table?.reload();
     } catch (err) {
       console.error('Rescan failed:', err);
       this.showToast('Rescan failed. Please try again.', 'error');
@@ -1030,6 +1134,34 @@ class HistoryManager {
         btn.disabled = false;
         btn.innerHTML = origHtml;
       }
+    }
+  }
+
+  /**
+   * "Reanalyze" from the row menu. Same request as the modal button, minus the
+   * modal: the menu closes itself on click, so there is no spinner to restore
+   * and nothing to hide once the document is queued.
+   */
+  async rescanFromRow(documentId) {
+    // Wording taken from the modal path on purpose — the same action should not
+    // report itself differently depending on where it was started.
+    let message =
+      'Document sent for rescan. It might take a few moments to process.';
+    let tone = 'success';
+
+    try {
+      await this.postRescan(documentId);
+    } catch (err) {
+      console.error('Rescan failed:', err);
+      message = 'Rescan failed. Please try again.';
+      tone = 'error';
+    }
+
+    this.showToast(message, tone);
+    // The backend drops the processing record, so the row leaves the table
+    // until the document has been analyzed again.
+    if (tone === 'success') {
+      this.table?.reload();
     }
   }
 

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -266,9 +266,15 @@ class HistoryManager {
           // One labelled action plus the overflow, like the queue pages. Wrapping
           // stays on for the card layout, where a phone has less room; inside
           // the table the actions column overrides it back to a single line.
-          render: (value, row) => {
+          render: (value, row, surface) => {
             const docId = escape(row.document_id ?? value);
-            const menuId = `historyRowMenu${docId}`;
+            // The table copy and the card copy of this row both exist in the
+            // DOM at all times; only one of them is displayed. Without the
+            // surface in the id, the card's button would target the table's
+            // menu, and a menu inside a display:none wrapper has no box to
+            // place — the popover opened and was dismissed again, so the row
+            // menu simply never appeared on a phone.
+            const menuId = `historyRowMenu-${surface || 'table'}-${docId}`;
             // _esc(), not escape(): the innerHTML round-trip behind escape()
             // leaves a double quote intact, and a Paperless-ngx title is free
             // text that would otherwise break out of the attribute.

--- a/public/js/modules/dashboard-layout.js
+++ b/public/js/modules/dashboard-layout.js
@@ -1,20 +1,34 @@
 /**
  * Dashboard layout module.
  *
- * Lets the user rearrange the dashboard grid: drag a card by its head to
- * reorder, drag the corner grip to resize. Both axes snap — width to the 12
- * grid columns the cards already use via data-span, height to whole tile rows —
- * so resized cards line up with their neighbours instead of landing at
- * arbitrary pixel heights. The result is stored per user through
- * /api/dashboard/layout, so it follows them to another browser.
+ * The dashboard is view-only until the user asks for it: "Edit dashboard" opens
+ * a session, and only inside that session can a card be dragged by its head,
+ * resized from its corner grip, or switched off from the tray above the grid.
+ * Nothing is written while the session runs — Done sends the whole arrangement
+ * in one request, Cancel puts the grid back exactly as it was found. A
+ * dashboard that is only being read never writes anything, and a session the
+ * user walks away from leaves no trace.
+ *
+ * Both axes snap — width to the 12 grid columns the cards already use via
+ * data-span, height to whole tile rows — so a resized card lines up with its
+ * neighbours instead of landing at an arbitrary pixel height. The result is
+ * stored per user through /api/dashboard/layout, so it follows them to another
+ * browser.
  *
  * A sized card is a tile, not a document: it shows what fits and never scrolls.
  * What did not fit fades out, and the card's own footer link is the way to the
  * full list. The content adapts to the tile through the height container
  * queries in pages/dashboard.css.
  *
+ * The wire format is storage v1 (documented in routes/setup.js): named
+ * dashboards, each holding its cards in display order. This module ships a
+ * single board and only ever writes that one; it reads back whichever board the
+ * stored config points at, so a later multi-board UI can grow around it without
+ * changing what is on disk.
+ *
  * Below 861px the grid is a single column and every card spans the full width,
- * so editing is switched off there rather than storing a layout nobody can see.
+ * so a session cannot be opened there rather than storing a layout nobody can
+ * see. A viewport that shrinks mid-session ends it the way Cancel does.
  */
 
 const LAYOUT_URL = '/api/dashboard/layout';
@@ -24,9 +38,14 @@ const MIN_SPAN = 3;
 // than 24 is taller than any viewport this grid is used on.
 const MIN_ROWS = 3;
 const MAX_ROWS = 24;
-const SAVE_DEBOUNCE_MS = 600;
 const DESKTOP_QUERY = '(min-width: 861px)';
 const REQUEST_TIMEOUT_MS = 15000;
+
+/* The one board this module owns. The slug and the name are validated on the
+   way in, so they are spelled the same way the server's own defaults are. */
+const STORAGE_VERSION = 1;
+const BOARD_SLUG = 'default';
+const BOARD_NAME = 'Dashboard';
 
 async function fetchJson(url, options = {}) {
   const controller = new AbortController();
@@ -52,29 +71,57 @@ export default function dashboardLayout(grid, { toast } = {}) {
   if (cards.length === 0) return undefined;
 
   const desktop = window.matchMedia(DESKTOP_QUERY);
-  // The order and spans the server rendered. Reset means going back to these,
-  // and it has to be captured before the stored layout is applied.
+  const cardsById = new Map(cards.map((card) => [card.dataset.widget, card]));
+  // The order and spans the server rendered, every card showing. Reset means
+  // going back to these, and they have to be captured before a stored layout is
+  // applied over them.
   const defaults = cards.map((card) => ({
     card,
     span: Number(card.dataset.span) || GRID_COLUMNS,
   }));
 
-  let saveTimer = 0;
+  // Every listener put on something that outlives this module goes through this
+  // signal, so destroy() is one abort() instead of a list to keep in sync.
+  const listeners = new AbortController();
+  const { signal } = listeners;
+
+  // The tray is server-rendered (views/dashboard.ejs) and starts hidden. It is
+  // the entire UI of the session, so without it the grid stays view-only.
+  const editbar = document.getElementById('dashboardEditbar');
+  const chips = new Map();
+
   let sortable = null;
-  let resetButton = null;
-  // Whether a stored layout exists — the reset control has nothing to offer
-  // until the user has actually moved something.
-  let hasStoredLayout = false;
+  let layoutBar = null;
+  let editButton = null;
+  let editing = false;
+  let saving = false;
+  // Editing before the stored layout has landed would arrange cards that are
+  // about to be rearranged by the answer, so the way in opens once it is here.
+  let ready = false;
+  // The grid as the session found it: what Cancel puts back.
+  let snapshot = null;
+  // "Give me the defaults back" is a different write from "store this": see
+  // commitEdit().
+  let resetRequested = false;
 
   /* --- reading and writing the grid -------------------------------------- */
 
   function currentLayout() {
     return {
-      widgets: [...grid.querySelectorAll('[data-widget]')].map((card) => ({
-        id: card.dataset.widget,
-        span: Number(card.dataset.span) || GRID_COLUMNS,
-        rows: Number(card.dataset.rows) || 0,
-      })),
+      version: STORAGE_VERSION,
+      active: BOARD_SLUG,
+      dashboards: [
+        {
+          slug: BOARD_SLUG,
+          name: BOARD_NAME,
+          widgets: [...grid.querySelectorAll('[data-widget]')].map((card) => ({
+            id: card.dataset.widget,
+            span: Number(card.dataset.span) || GRID_COLUMNS,
+            rows: Number(card.dataset.rows) || 0,
+            hidden: card.classList.contains('is-hidden'),
+          })),
+        },
+      ],
     };
   }
 
@@ -95,6 +142,16 @@ export default function dashboardLayout(grid, { toast } = {}) {
     const value = clamp(Math.round(rows), MIN_ROWS, MAX_ROWS);
     card.dataset.rows = String(value);
     card.style.setProperty('--zr-rows', String(value));
+    markClipping();
+  }
+
+  /* Switched off is a class, never a removal: the card keeps its place in the
+     DOM, so its own module keeps its instance and the dashboard's fetch goes on
+     writing into it. Switching it back on costs nothing and shows live numbers
+     rather than an empty card. The stylesheet decides what "off" looks like —
+     gone while reading, faded but still draggable inside the session. */
+  function setHidden(card, hidden) {
+    card.classList.toggle('is-hidden', hidden);
     markClipping();
   }
 
@@ -133,94 +190,263 @@ export default function dashboardLayout(grid, { toast } = {}) {
     characterData: true,
   });
 
-  function applyLayout(layout) {
-    const widgets = Array.isArray(layout?.widgets) ? layout.widgets : [];
-    const known = new Map(cards.map((card) => [card.dataset.widget, card]));
+  function applyLayout(data) {
+    const dashboards = Array.isArray(data?.dashboards) ? data.dashboards : [];
+    // active is a pointer, and a stale one falls back to the first board rather
+    // than to nothing — the same rule the server applies when it stores.
+    const board =
+      dashboards.find((entry) => entry?.slug === data?.active) || dashboards[0];
+    const stored = Array.isArray(board?.widgets) ? board.widgets : [];
 
-    widgets.forEach((entry) => {
-      const card = known.get(entry.id);
-      // A stored id the dashboard no longer ships is simply dropped; a card the
-      // stored layout predates keeps its markup position at the end.
+    // Nothing arranged — no config, no boards, or a board that only carries a
+    // name — means the arrangement the server rendered.
+    if (stored.length === 0) {
+      applyDefaults();
+      return;
+    }
+
+    const pending = new Map(cardsById);
+    stored.forEach((entry) => {
+      const card = pending.get(entry?.id);
+      // A stored id the dashboard no longer ships is simply dropped.
       if (!card) return;
       setSpan(card, Number(entry.span));
       setRows(card, Number(entry.rows) || 0);
+      setHidden(card, Boolean(entry.hidden));
       grid.appendChild(card);
-      known.delete(entry.id);
+      pending.delete(entry.id);
     });
-    known.forEach((card) => grid.appendChild(card));
+    // A card the stored layout predates is new to this user: an update that
+    // ships a widget has to surface it, so it lands at the end and shows.
+    pending.forEach((card) => {
+      setHidden(card, false);
+      grid.appendChild(card);
+    });
 
-    hasStoredLayout = widgets.length > 0;
-    syncResetButton();
+    syncChips();
   }
 
   function applyDefaults() {
     defaults.forEach(({ card, span }) => {
       setSpan(card, span);
       setRows(card, 0);
+      setHidden(card, false);
       grid.appendChild(card);
     });
-    hasStoredLayout = false;
-    syncResetButton();
+    syncChips();
   }
 
-  /* --- persistence ------------------------------------------------------- */
+  /* --- the edit session -------------------------------------------------- */
 
-  function save() {
-    clearTimeout(saveTimer);
-    saveTimer = setTimeout(async () => {
-      const layout = currentLayout();
-      try {
-        await fetchJson(LAYOUT_URL, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(layout),
-        });
-        hasStoredLayout = true;
-        syncResetButton();
-      } catch (error) {
-        console.error('[dashboard-layout] saving failed', error);
-        toast?.('Could not save the dashboard layout.', { tone: 'danger' });
-      }
-    }, SAVE_DEBOUNCE_MS);
+  function takeSnapshot() {
+    return [...grid.querySelectorAll('[data-widget]')].map((card) => ({
+      card,
+      span: Number(card.dataset.span) || GRID_COLUMNS,
+      rows: Number(card.dataset.rows) || 0,
+      hidden: card.classList.contains('is-hidden'),
+    }));
   }
 
-  async function reset() {
-    clearTimeout(saveTimer);
+  /* Re-appending every card in the order it was captured in restores the order
+     as a side effect, so one pass puts back all four properties. */
+  function restoreSnapshot(entries) {
+    (entries || []).forEach(({ card, span, rows, hidden }) => {
+      setSpan(card, span);
+      setRows(card, rows);
+      setHidden(card, hidden);
+      grid.appendChild(card);
+    });
+    syncChips();
+  }
+
+  /* Anything the user does after a reset means they are building on top of the
+     defaults, so Done has to store that arrangement instead of clearing the
+     row. Every interactive path calls this. */
+  function markEdited() {
+    resetRequested = false;
+  }
+
+  function enterEdit() {
+    if (editing || saving || !ready || !editbar || !desktop.matches) return;
+    snapshot = takeSnapshot();
+    resetRequested = false;
+    editing = true;
+    grid.classList.add('is-editing');
+    editbar.classList.remove('hidden');
+    syncEditButton();
+    enableSorting();
+    markClipping();
+    // The button that opened the session has just hidden itself, so the focus
+    // it held would fall to the top of the document; the tray takes it over.
+    editbar.focus();
+  }
+
+  function leaveEdit() {
+    if (!editing) return;
+    editing = false;
+    snapshot = null;
+    resetRequested = false;
+    grid.classList.remove('is-editing');
+    editbar.classList.add('hidden');
+    disableSorting();
+    syncEditButton();
+    markClipping();
+    // Focus goes back to the control that opened the session — unless the
+    // viewport just took that control away, which is the mid-session shrink.
+    if (editButton && !editButton.classList.contains('hidden')) {
+      editButton.focus();
+    }
+  }
+
+  function cancelEdit() {
+    if (!editing) return;
+    restoreSnapshot(snapshot);
+    leaveEdit();
+  }
+
+  /* Reset inside the session only touches the grid. Nothing is written until
+     Done, so a reset the user thinks better of is undone by Cancel like any
+     other change. */
+  function resetInSession() {
+    if (!editing || saving) return;
     applyDefaults();
+    // What Done will write, until the next edit clears it again.
+    resetRequested = true;
+  }
+
+  function setBusy(busy) {
+    saving = busy;
+    editbar
+      ?.querySelectorAll('.zr-editbar__actions button, .zr-editbar__chip')
+      .forEach((button) => {
+        button.disabled = busy;
+      });
+  }
+
+  async function commitEdit() {
+    if (!editing || saving) return;
+    const wasReset = resetRequested;
+    /* A reset the user confirms with Done clears the stored layout rather than
+       storing a default-shaped one. That is the difference between "I like the
+       current defaults" and "give me the defaults" — only the second keeps
+       following them, so a release that changes a span or ships a new card
+       reaches this user instead of being frozen out by their own copy of
+       yesterday's defaults. An empty dashboards list is what the server reads
+       as "nothing arranged"; if it ever stopped doing so the write would be
+       rejected rather than silently stored wrong. */
+    const payload = wasReset
+      ? { version: STORAGE_VERSION, active: BOARD_SLUG, dashboards: [] }
+      : currentLayout();
+
+    setBusy(true);
     try {
       await fetchJson(LAYOUT_URL, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ widgets: [] }),
+        body: JSON.stringify(payload),
       });
-      toast?.('Dashboard layout reset.', { tone: 'ok' });
+      leaveEdit();
+      toast?.(
+        wasReset ? 'Dashboard layout reset.' : 'Dashboard layout saved.',
+        {
+          tone: 'ok',
+        }
+      );
     } catch (error) {
-      console.error('[dashboard-layout] reset failed', error);
-      toast?.('Could not reset the dashboard layout.', { tone: 'danger' });
+      // The session stays open on failure: the arrangement is still on screen,
+      // and one more click on Done is a cheaper recovery than doing it again.
+      console.error('[dashboard-layout] saving failed', error);
+      toast?.('Could not save the dashboard layout.', { tone: 'danger' });
+    } finally {
+      setBusy(false);
     }
   }
 
-  /* --- reset control ----------------------------------------------------- */
+  /* --- the tray ---------------------------------------------------------- */
 
-  function syncResetButton() {
-    if (!resetButton) return;
-    resetButton.classList.toggle(
+  /* aria-pressed is the state: pressed means the card is on the dashboard. It
+     is derived from the cards themselves rather than tracked alongside them, so
+     the chips cannot drift from what is on screen. */
+  function syncChips() {
+    chips.forEach((chip, id) => {
+      const card = cardsById.get(id);
+      if (!card) return;
+      chip.setAttribute(
+        'aria-pressed',
+        String(!card.classList.contains('is-hidden'))
+      );
+    });
+  }
+
+  function setupChips() {
+    if (!editbar) return;
+    editbar.querySelectorAll('[data-widget-toggle]').forEach((chip) => {
+      const id = chip.dataset.widgetToggle;
+      const card = cardsById.get(id);
+      // A chip whose card is not on the page would toggle nothing, which is
+      // worse than no chip at all.
+      if (!card) {
+        chip.remove();
+        return;
+      }
+      // The label is filled from the card, not from the registry: the title is
+      // already in the partial, and a second copy would drift from it.
+      const label = chip.querySelector('span') || chip;
+      label.textContent =
+        card.querySelector('.zr-module__title')?.textContent?.trim() || id;
+      chip.addEventListener(
+        'click',
+        () => {
+          setHidden(card, !card.classList.contains('is-hidden'));
+          syncChips();
+          markEdited();
+        },
+        { signal }
+      );
+      chips.set(id, chip);
+    });
+    syncChips();
+  }
+
+  function wireEditbar() {
+    if (!editbar) return;
+    editbar
+      .querySelector('#dashboardEditReset')
+      ?.addEventListener('click', resetInSession, { signal });
+    editbar
+      .querySelector('#dashboardEditCancel')
+      ?.addEventListener('click', cancelEdit, { signal });
+    editbar
+      .querySelector('#dashboardEditDone')
+      ?.addEventListener('click', commitEdit, { signal });
+  }
+
+  /* --- the way in -------------------------------------------------------- */
+
+  function syncEditButton() {
+    if (!editButton) return;
+    // One control at a time: the button opens the session, the tray runs it.
+    editButton.classList.toggle(
       'hidden',
-      !hasStoredLayout || !desktop.matches
+      editing || !ready || !desktop.matches
     );
   }
 
-  function buildResetButton() {
-    const bar = document.createElement('div');
-    bar.className = 'zr-row zr-layoutbar';
-    resetButton = document.createElement('button');
-    resetButton.type = 'button';
-    resetButton.className = 'zr-btn zr-btn--ghost hidden';
-    resetButton.innerHTML =
-      '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-refresh"/></svg><span>Reset layout</span>';
-    resetButton.addEventListener('click', reset);
-    bar.appendChild(resetButton);
-    grid.parentNode.insertBefore(bar, grid);
+  function buildEditButton() {
+    // Without a tray there is nothing to open, so the grid stays view-only.
+    if (!editbar) return;
+    layoutBar = document.createElement('div');
+    layoutBar.className = 'zr-row zr-layoutbar';
+    editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'zr-btn zr-btn--ghost hidden';
+    editButton.innerHTML =
+      '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-grip"/></svg><span>Edit dashboard</span>';
+    editButton.addEventListener('click', enterEdit, { signal });
+    layoutBar.appendChild(editButton);
+    // Above the tray, which sits directly above the grid: the two are never
+    // shown at the same time, and the tab order reads top to bottom either way.
+    editbar.parentNode.insertBefore(layoutBar, editbar);
   }
 
   /* --- resizing ---------------------------------------------------------- */
@@ -257,7 +483,9 @@ export default function dashboardLayout(grid, { toast } = {}) {
   }
 
   function startResize(card, event) {
-    if (!desktop.matches) return;
+    // The grip is only on screen inside a session; this is the belt to that
+    // stylesheet brace.
+    if (!editing) return;
     event.preventDefault();
 
     const grip = event.currentTarget;
@@ -274,7 +502,7 @@ export default function dashboardLayout(grid, { toast } = {}) {
       grip.removeEventListener('pointerup', onUp);
       grip.removeEventListener('pointercancel', onUp);
       card.classList.remove('is-resizing');
-      save();
+      markEdited();
     };
 
     grip.addEventListener('pointermove', onMove);
@@ -283,8 +511,10 @@ export default function dashboardLayout(grid, { toast } = {}) {
   }
 
   /* The grip is the keyboard path into everything the mouse can do: arrows
-     resize, shift and arrows move the card, delete gives the height back. */
+     resize, shift and arrows move the card, delete gives the height back. Like
+     the mouse it only changes the grid — the session is what gets saved. */
   function onGripKey(card, event) {
+    if (!editing) return;
     const moving = event.shiftKey;
     const ordered = [...grid.querySelectorAll('[data-widget]')];
     const index = ordered.indexOf(card);
@@ -328,7 +558,7 @@ export default function dashboardLayout(grid, { toast } = {}) {
     // Moving the card re-inserts it, which drops the focus — without this the
     // second arrow press would go nowhere.
     event.currentTarget.focus();
-    save();
+    markEdited();
   }
 
   function addGrip(card) {
@@ -339,21 +569,30 @@ export default function dashboardLayout(grid, { toast } = {}) {
       'aria-label',
       `Resize ${card.querySelector('.zr-module__title')?.textContent?.trim() || 'widget'}: arrow keys resize, shift and arrow keys move, delete fits the card to its content`
     );
-    grip.addEventListener('pointerdown', (event) => startResize(card, event));
+    grip.addEventListener('pointerdown', (event) => startResize(card, event), {
+      signal,
+    });
     // Double-click hands the card back to its content — the way out of a tile
     // size without hunting for the exact row count.
-    grip.addEventListener('dblclick', () => {
-      setRows(card, 0);
-      save();
+    grip.addEventListener(
+      'dblclick',
+      () => {
+        if (!editing) return;
+        setRows(card, 0);
+        markEdited();
+      },
+      { signal }
+    );
+    grip.addEventListener('keydown', (event) => onGripKey(card, event), {
+      signal,
     });
-    grip.addEventListener('keydown', (event) => onGripKey(card, event));
     card.appendChild(grip);
   }
 
   /* --- drag ordering ----------------------------------------------------- */
 
   function enableSorting() {
-    if (sortable || !window.Sortable || !desktop.matches) return;
+    if (sortable || !window.Sortable || !editing) return;
     sortable = window.Sortable.create(grid, {
       handle: '.zr-module__head',
       draggable: '[data-widget]',
@@ -363,8 +602,10 @@ export default function dashboardLayout(grid, { toast } = {}) {
       // Buttons live in the head as well, so a click must not start a drag.
       filter: 'button, a, input, select',
       preventOnFilter: false,
-      onEnd: save,
+      onEnd: markEdited,
     });
+    // The narrower flag: the grab cursor only promises a drag once the vendor
+    // script is really attached.
     grid.classList.add('is-sortable');
   }
 
@@ -376,38 +617,51 @@ export default function dashboardLayout(grid, { toast } = {}) {
   }
 
   function syncMode() {
-    if (desktop.matches) {
-      enableSorting();
-    } else {
-      disableSorting();
+    // Shrinking into the phone layout ends the session the way Cancel does: a
+    // single column cannot show what was being arranged, and storing a layout
+    // the user can no longer check is worse than dropping the edit.
+    if (!desktop.matches && editing) {
+      cancelEdit();
     }
-    grid.classList.toggle('is-editable', desktop.matches);
-    syncResetButton();
+    syncEditButton();
     markClipping();
   }
 
   /* --- start ------------------------------------------------------------- */
 
-  buildResetButton();
+  setupChips();
+  wireEditbar();
+  buildEditButton();
   cards.forEach(addGrip);
   syncMode();
-  desktop.addEventListener('change', syncMode);
+  desktop.addEventListener('change', syncMode, { signal });
 
   fetchJson(LAYOUT_URL)
     .then((result) => applyLayout(result?.data))
     .catch((error) => {
       // A dashboard that cannot read its layout still works — it just shows the
-      // default arrangement.
+      // default arrangement. Editing stays open: the user can still arrange the
+      // cards, and Done will say whether the write got through either.
       console.error('[dashboard-layout] loading failed', error);
+    })
+    .finally(() => {
+      ready = true;
+      syncEditButton();
     });
 
   return {
     destroy() {
-      clearTimeout(saveTimer);
       cancelAnimationFrame(clipFrame);
       contentObserver.disconnect();
       disableSorting();
-      desktop.removeEventListener('change', syncMode);
+      listeners.abort();
+      editing = false;
+      grid.classList.remove('is-editing');
+      editbar?.classList.add('hidden');
+      layoutBar?.remove();
+      grid
+        .querySelectorAll('.zr-module__grip')
+        .forEach((grip) => grip.remove());
     },
   };
 }

--- a/public/js/modules/dashboard-layout.js
+++ b/public/js/modules/dashboard-layout.js
@@ -39,6 +39,14 @@ const MIN_SPAN = 3;
 const MIN_ROWS = 3;
 const MAX_ROWS = 24;
 const DESKTOP_QUERY = '(min-width: 861px)';
+// Below this, modules.css collapses the grid to two usable widths: spans 3, 4
+// and 6 render as half, everything else as full. Snapping to the raw 1..12
+// model there hands the user a card that jumps backwards under their own
+// pointer and stores a width they never saw, so the snapping follows the
+// stylesheet instead. Keep the two in step — see the media query in
+// public/css/modules.css.
+const WIDE_QUERY = '(min-width: 1181px)';
+const HALF_SPAN = 6;
 const REQUEST_TIMEOUT_MS = 15000;
 
 /* The one board this module owns. The slug and the name are validated on the
@@ -71,6 +79,9 @@ export default function dashboardLayout(grid, { toast } = {}) {
   if (cards.length === 0) return undefined;
 
   const desktop = window.matchMedia(DESKTOP_QUERY);
+  // Editing is offered from 861px, but the grid only honours every span from
+  // 1181px. Between the two, resizing has fewer widths to offer — see snapSpan.
+  const wide = window.matchMedia(WIDE_QUERY);
   const cardsById = new Map(cards.map((card) => [card.dataset.widget, card]));
   // The order and spans the server rendered, every card showing. Reset means
   // going back to these, and they have to be captured before a stored layout is
@@ -468,9 +479,31 @@ export default function dashboardLayout(grid, { toast } = {}) {
     };
   }
 
+  /* Only the widths the current viewport can actually render. Wide viewports
+     honour every span; narrower ones show half or full and nothing between, so
+     that is what a resize there is allowed to produce. */
+  function snapSpan(span) {
+    const bounded = clamp(span, MIN_SPAN, GRID_COLUMNS);
+    if (wide.matches) return bounded;
+    // Nearest of the two, so the card follows the pointer to whichever width is
+    // closer rather than flipping at the halfway point of the smaller one.
+    return bounded < (HALF_SPAN + GRID_COLUMNS) / 2 ? HALF_SPAN : GRID_COLUMNS;
+  }
+
   function spanForWidth(width) {
     const { column, gap } = gridMetrics();
-    return clamp(Math.round((width + gap) / column), MIN_SPAN, GRID_COLUMNS);
+    return snapSpan(Math.round((width + gap) / column));
+  }
+
+  /* One step in the direction asked for. Between 861 and 1180px there are only
+     two widths, so a step is the jump between them rather than a column that
+     would not change anything on screen. */
+  function stepSpan(card, direction) {
+    const current = Number(card.dataset.span) || GRID_COLUMNS;
+    if (!wide.matches) {
+      return direction > 0 ? GRID_COLUMNS : HALF_SPAN;
+    }
+    return snapSpan(current + direction);
   }
 
   function rowsForHeight(height) {
@@ -526,7 +559,7 @@ export default function dashboardLayout(grid, { toast } = {}) {
         if (moving) {
           if (after) grid.insertBefore(after, card);
         } else {
-          setSpan(card, (Number(card.dataset.span) || GRID_COLUMNS) + 1);
+          setSpan(card, stepSpan(card, 1));
         }
         break;
       }
@@ -535,7 +568,7 @@ export default function dashboardLayout(grid, { toast } = {}) {
         if (moving) {
           if (before) grid.insertBefore(card, before);
         } else {
-          setSpan(card, (Number(card.dataset.span) || GRID_COLUMNS) - 1);
+          setSpan(card, stepSpan(card, -1));
         }
         break;
       }

--- a/public/js/modules/dashboard.js
+++ b/public/js/modules/dashboard.js
@@ -345,15 +345,33 @@ export default function dashboard(root, { toast }) {
   // Every figure on this page is polled. When a poll fails the old numbers stay
   // on screen, so the page has to say so — a toast that fades leaves a dashboard
   // that looks current and is not.
-  let lastUpdatedAt = null;
   const failures = new Map();
+  // When each source last delivered, keyed by source. One shared timestamp did
+  // not work: the status poll succeeds every three seconds, so it kept
+  // restamping the label to "now" and hid the age of the statistics, which come
+  // out of a server-side cache and can legitimately be a minute old — or much
+  // older when Paperless-ngx is down and the cache is being served stale.
+  const freshAt = new Map();
+
+  // The oldest thing on screen is the honest claim for a label that covers the
+  // whole page.
+  function oldestFresh() {
+    // A source that has never answered has no age to report, and borrowing the
+    // other one's would date figures that are not on screen at all.
+    for (const source of failures.keys()) {
+      if (!freshAt.has(source)) return null;
+    }
+    if (!freshAt.size) return null;
+    return new Date(Math.min(...freshAt.values()));
+  }
 
   function renderFreshness() {
     const label = byId('statusLastUpdated');
     if (!label) return;
 
     const reason = [...failures.values()][0] || '';
-    const at = lastUpdatedAt ? lastUpdatedAt.toLocaleTimeString() : '';
+    const updatedAt = oldestFresh();
+    const at = updatedAt ? updatedAt.toLocaleTimeString() : '';
     if (!reason) {
       label.textContent = at ? `updated ${at}` : '';
     } else {
@@ -369,12 +387,11 @@ export default function dashboard(root, { toast }) {
   // paper over a statistics endpoint that is still failing.
   // `at` is the epoch-millisecond timestamp at which the data was assembled —
   // the statistics endpoint answers from a cache, so the time of the fetch is
-  // not the age of the numbers it returned.
+  // not the age of the numbers it returned. Sources that have no such stamp
+  // (the status poll builds its answer per request) date themselves to now.
   function markFresh(source, at = null) {
     failures.delete(source);
-    if (!failures.size) {
-      lastUpdatedAt = Number.isFinite(at) && at > 0 ? new Date(at) : new Date();
-    }
+    freshAt.set(source, Number.isFinite(at) && at > 0 ? at : Date.now());
     renderFreshness();
   }
 

--- a/public/js/modules/dashboard.js
+++ b/public/js/modules/dashboard.js
@@ -367,9 +367,14 @@ export default function dashboard(root, { toast }) {
 
   // Tracked per source: the status poll succeeding every three seconds must not
   // paper over a statistics endpoint that is still failing.
-  function markFresh(source) {
+  // `at` is the epoch-millisecond timestamp at which the data was assembled —
+  // the statistics endpoint answers from a cache, so the time of the fetch is
+  // not the age of the numbers it returned.
+  function markFresh(source, at = null) {
     failures.delete(source);
-    if (!failures.size) lastUpdatedAt = new Date();
+    if (!failures.size) {
+      lastUpdatedAt = Number.isFinite(at) && at > 0 ? new Date(at) : new Date();
+    }
     renderFreshness();
   }
 
@@ -389,7 +394,7 @@ export default function dashboard(root, { toast }) {
       if (!payload?.success)
         throw new Error(payload?.error || 'Invalid dashboard stats response');
       applyStats(payload);
-      markFresh('stats');
+      markFresh('stats', payload.cachedAt);
     } catch (error) {
       console.error('[dashboard] stats failed', error);
       markStale('stats', 'Statistics could not be loaded');

--- a/public/js/modules/data-table.js
+++ b/public/js/modules/data-table.js
@@ -112,8 +112,16 @@ export function createTable(root, options) {
     });
   }
 
-  function cellHtml(col, row) {
-    if (typeof col.render === 'function') return col.render(row[col.key], row);
+  // Every row is rendered twice — once into the table, once into the card list
+  // that replaces it below the mobile breakpoint — so a renderer that mints an
+  // element id would mint it twice. `surface` lets it tell the two apart:
+  // duplicate ids are not merely untidy here, they break `popovertarget` and
+  // getElementById, which resolve to the first match in tree order and would
+  // always find the copy inside the hidden table.
+  function cellHtml(col, row, surface) {
+    if (typeof col.render === 'function') {
+      return col.render(row[col.key], row, surface);
+    }
     return escapeHtml(row[col.key]);
   }
 
@@ -129,7 +137,7 @@ export function createTable(root, options) {
             `<tr data-row-id="${escapeHtml(rowId(row))}">${columns
               .map(
                 (col) =>
-                  `<td${col.cellClass ? ` class="${col.cellClass}"` : ''}>${cellHtml(col, row)}</td>`
+                  `<td${col.cellClass ? ` class="${col.cellClass}"` : ''}>${cellHtml(col, row, 'table')}</td>`
               )
               .join('')}</tr>`
         )
@@ -143,7 +151,7 @@ export function createTable(root, options) {
               .map((col) => {
                 if (col.mobile === false) return '';
                 const label = col.mobileLabel ?? col.label;
-                return `<div class="zr-table-card__row"><span class="zr-table-card__label">${escapeHtml(label)}</span><span class="zr-table-card__value">${cellHtml(col, row)}</span></div>`;
+                return `<div class="zr-table-card__row"><span class="zr-table-card__label">${escapeHtml(label)}</span><span class="zr-table-card__value">${cellHtml(col, row, 'card')}</span></div>`;
               })
               .join('')}</article>`
         )

--- a/public/js/modules/section-nav.js
+++ b/public/js/modules/section-nav.js
@@ -32,6 +32,11 @@ export default function sectionNav(el) {
       );
       highlight();
     },
+    // The top inset stands in for what the sticky topbar covers, the same offset
+    // css/pages/settings.css gives these sections as scroll-margin-top, so the
+    // section a link scrolls to is also the one the link then highlights. The
+    // bottom one cuts the reading band off above the fold, so a section entering
+    // from below does not take the highlight before it is being read.
     { rootMargin: '-56px 0px -55% 0px', threshold: 0 }
   );
   targets.forEach((t) => io.observe(t));

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3427,6 +3427,11 @@ async function saveDocumentChanges(docId, updateData, analysis, originalData) {
       historyLanguage
     ),
   ]);
+
+  // Document counters and token figures just moved. Every path that writes
+  // processed_documents has to say so, or the dashboard serves numbers from
+  // before the change for up to a full TTL.
+  dashboardStatsService.invalidate();
 }
 
 /**
@@ -7726,6 +7731,7 @@ router.post('/manual/updateDocument', express.json(), async (req, res) => {
 
     // Mark document as processed
     await documentModel.addProcessedDocument(documentId, updateData.title);
+    dashboardStatsService.invalidate();
 
     res.json(updateDocument);
   } catch (error) {
@@ -9441,6 +9447,7 @@ router.post(
           send({ step, message, ...data });
         },
       });
+      dashboardStatsService.invalidate();
     } catch (error) {
       send({ step: 'error', message: error.message });
     }
@@ -9541,6 +9548,7 @@ router.post('/api/ocr/process-all', isAuthenticated, async (req, res) => {
           },
         });
         completed++;
+        dashboardStatsService.invalidate();
       } catch (err) {
         failed++;
         send({

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -10282,7 +10282,6 @@ const DASHBOARD_CONFIG_VERSION = 1;
 const DASHBOARD_MAX_BOARDS = 10;
 const DASHBOARD_MAX_NAME_LENGTH = 60;
 const DASHBOARD_DEFAULT_SLUG = 'default';
-const DASHBOARD_DEFAULT_NAME = 'Dashboard';
 
 /* Nothing stored: a valid v1 config that asks for the defaults. */
 function emptyDashboardConfig() {
@@ -10339,48 +10338,6 @@ function normalizeDashboardWidgets(input) {
   }
 
   return widgets;
-}
-
-/* INTERIM COMPAT — delete with the edit-mode batch.
-   -------------------------------------------------
-   public/js/modules/dashboard-layout.js still speaks the old flat format and
-   PUTs { widgets: [...] }. Rather than freezing the storage format until that
-   module is rewritten, the old body is wrapped here into a v1 config with a
-   single 'default' board. Nothing else in the codebase writes the flat shape,
-   so when the module starts sending v1 this function, its call in the PUT
-   handler and withLegacyWidgetsAlias() below all go away together. */
-function adaptLegacyDashboardPayload(input) {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    return input;
-  }
-  // Already v1, or not the old shape either — hand it to the validator as-is
-  // and let it decide.
-  if (Array.isArray(input.dashboards) || !Array.isArray(input.widgets)) {
-    return input;
-  }
-
-  return {
-    version: DASHBOARD_CONFIG_VERSION,
-    active: DASHBOARD_DEFAULT_SLUG,
-    dashboards: [
-      {
-        slug: DASHBOARD_DEFAULT_SLUG,
-        name: DASHBOARD_DEFAULT_NAME,
-        widgets: input.widgets,
-      },
-    ],
-  };
-}
-
-/* INTERIM COMPAT — delete with the edit-mode batch.
-   The same module reads result.data.widgets, so GET answers with the v1 object
-   plus a top-level alias of the active board's cards. Documented as deprecated
-   in the @swagger block; nothing new may read it. */
-function withLegacyWidgetsAlias(dashboardConfig) {
-  const active = dashboardConfig.dashboards.find(
-    (board) => board.slug === dashboardConfig.active
-  );
-  return { ...dashboardConfig, widgets: active ? active.widgets : [] };
 }
 
 /* "Give me the defaults back" arrives in two shapes: no boards at all, or the
@@ -10527,15 +10484,6 @@ function normalizeDashboardConfig(input) {
  *                                 hidden:
  *                                   type: boolean
  *                                   example: false
- *                     widgets:
- *                       type: array
- *                       deprecated: true
- *                       description: >
- *                         Deprecated alias for the active dashboard's widgets,
- *                         kept only until the browser module speaks the
- *                         named-dashboard format. Read dashboards instead.
- *                       items:
- *                         type: object
  *       401:
  *         description: Not authenticated
  */
@@ -10543,10 +10491,7 @@ router.get('/api/dashboard/layout', isAuthenticated, async (req, res) => {
   try {
     const username = req.user && req.user.username;
     if (!username) {
-      return res.json({
-        success: true,
-        data: withLegacyWidgetsAlias(emptyDashboardConfig()),
-      });
+      return res.json({ success: true, data: emptyDashboardConfig() });
     }
 
     const stored = await documentModel.getDashboardLayout(username);
@@ -10561,10 +10506,7 @@ router.get('/api/dashboard/layout', isAuthenticated, async (req, res) => {
         ? stored
         : emptyDashboardConfig();
 
-    return res.json({
-      success: true,
-      data: withLegacyWidgetsAlias(dashboardConfig),
-    });
+    return res.json({ success: true, data: dashboardConfig });
   } catch (error) {
     console.error('[ERROR] GET /api/dashboard/layout:', error);
     return res
@@ -10594,10 +10536,6 @@ router.get('/api/dashboard/layout', isAuthenticated, async (req, res) => {
  *
  *       If active names a dashboard that is not in the payload it is replaced
  *       with the first dashboard's slug rather than rejecting the write.
- *
- *       Deprecated: a flat {widgets: [...]} body is still accepted and stored
- *       as the single 'default' dashboard, until the browser module speaks the
- *       named-dashboard format. Do not build on it.
  *     tags:
  *       - Dashboard
  *     security:
@@ -10679,23 +10617,18 @@ router.put(
         return res.json({ success: true, message: 'No user to store against' });
       }
 
-      // INTERIM COMPAT — delete with the edit-mode batch: the browser still
-      // sends the old flat { widgets: [...] } body, which is wrapped into a v1
-      // config here so both shapes reach the same validator.
-      const payload = adaptLegacyDashboardPayload(req.body);
-
       // Nothing arranged is not stored as "an empty arrangement": the row is
       // cleared, so the dashboard falls back to the registry order.
-      if (isDashboardResetRequest(payload)) {
+      if (isDashboardResetRequest(req.body)) {
         await documentModel.setDashboardLayout(username, null);
         return res.json({
           success: true,
-          data: withLegacyWidgetsAlias(emptyDashboardConfig()),
+          data: emptyDashboardConfig(),
           message: 'Dashboard layout reset',
         });
       }
 
-      const dashboardConfig = normalizeDashboardConfig(payload);
+      const dashboardConfig = normalizeDashboardConfig(req.body);
       if (!dashboardConfig) {
         return res
           .status(400)
@@ -10705,7 +10638,7 @@ router.put(
       await documentModel.setDashboardLayout(username, dashboardConfig);
       return res.json({
         success: true,
-        data: withLegacyWidgetsAlias(dashboardConfig),
+        data: dashboardConfig,
         message: 'Dashboard layout saved',
       });
     } catch (error) {

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -11,6 +11,7 @@ const documentModel = require('../models/document.js');
 const AIServiceFactory = require('../services/aiServiceFactory');
 const configFile = require('../config/config.js');
 const changelog = require('../config/changelog.js');
+const dashboardWidgets = require('../config/dashboardWidgets.js');
 const documentsService = require('../services/documentsService.js');
 const fs = require('fs').promises;
 const path = require('path');
@@ -6336,6 +6337,9 @@ router.get('/dashboard', async (req, res) => {
     },
     version,
     paperlessUrl,
+    // The cards the view loops over. Which widgets ship, in which order and how
+    // wide, is the registry's business — the view only renders what it is given.
+    dashboardWidgets,
   });
 });
 
@@ -10231,35 +10235,85 @@ router.get('/api/settings/env-file', isAuthenticated, async (req, res) => {
   }
 });
 
-/* The dashboard sends back the grid the user arranged. Widget ids are not
-   checked against a list on purpose — the dashboard adds and renames cards, and
-   a stale server list would silently drop a card's placement. The shape, the
-   spans and the count are what needs to be trustworthy; anything the dashboard
-   no longer knows is ignored when the layout is applied. */
+/* Dashboard storage format v1.
+   ---------------------------
+   The dashboard sends back the boards the user arranged:
+
+     {
+       version: 1,
+       active: 'default',
+       dashboards: [
+         {
+           slug: 'default',
+           name: 'Dashboard',
+           widgets: [{ id: 'task-runner', span: 12, rows: 0, hidden: false }]
+         }
+       ]
+     }
+
+   This blob goes straight into users.dashboard_layout, so the validator below
+   is the only thing between a hostile payload and the database. It rejects
+   whole configurations rather than repairing them: a payload it cannot vouch
+   for is a bug or an attack, and storing the salvageable half of either is
+   worse than a 400.
+
+   Widget and dashboard ids are deliberately not checked against a list. The
+   dashboard adds and renames cards, and a stale server-side list would silently
+   drop a card's placement; the shape, the spans and the counts are what has to
+   be trustworthy. Anything the browser no longer knows is ignored when the
+   layout is applied.
+
+   Two conventions run through the whole format:
+
+   - Absent means "use the defaults". No stored config, an empty dashboards
+     list, and a dashboard without widgets all say the same thing: render the
+     cards the way the server shipped them, in registry order.
+   - active is a pointer, not data. A slug that no longer resolves — a deleted
+     board, a stale client — falls back to the first dashboard instead of
+     failing the write. The arrangement is the valuable part, and landing on
+     board one beats losing it to a 400 over a name. */
 const DASHBOARD_WIDGET_ID = /^[a-z0-9][a-z0-9-]{0,39}$/;
 const DASHBOARD_MAX_WIDGETS = 50;
 const DASHBOARD_MIN_SPAN = 3;
 const DASHBOARD_GRID_COLUMNS = 12;
 const DASHBOARD_MIN_ROWS = 3;
 const DASHBOARD_MAX_ROWS = 24;
+const DASHBOARD_CONFIG_VERSION = 1;
+const DASHBOARD_MAX_BOARDS = 10;
+const DASHBOARD_MAX_NAME_LENGTH = 60;
+const DASHBOARD_DEFAULT_SLUG = 'default';
+const DASHBOARD_DEFAULT_NAME = 'Dashboard';
 
-function normalizeDashboardLayout(input) {
-  if (!input || !Array.isArray(input.widgets)) {
+/* Nothing stored: a valid v1 config that asks for the defaults. */
+function emptyDashboardConfig() {
+  return {
+    version: DASHBOARD_CONFIG_VERSION,
+    active: DASHBOARD_DEFAULT_SLUG,
+    dashboards: [],
+  };
+}
+
+/* One board's cards, cleaned. Returns null — not a partial list — as soon as
+   anything is off, so a single bad card takes the whole write down with it. */
+function normalizeDashboardWidgets(input) {
+  if (!Array.isArray(input)) {
     return null;
   }
-  if (input.widgets.length > DASHBOARD_MAX_WIDGETS) {
+  if (input.length > DASHBOARD_MAX_WIDGETS) {
     return null;
   }
 
   const seen = new Set();
   const widgets = [];
-  for (const entry of input.widgets) {
+  for (const entry of input) {
     const id = String(entry?.id || '').trim();
     if (!DASHBOARD_WIDGET_ID.test(id) || seen.has(id)) {
       return null;
     }
     seen.add(id);
 
+    // span and rows are parsed rather than compared: they are read off DOM
+    // datasets in the browser, where everything is a string.
     const span = Number.parseInt(entry?.span, 10);
     if (
       !Number.isInteger(span) ||
@@ -10279,28 +10333,209 @@ function normalizeDashboardLayout(input) {
       return null;
     }
 
-    widgets.push({ id, span, rows });
+    // hidden is a toggle, not data: absent, null or anything falsy means the
+    // card is shown. Nothing to reject here, so nothing does.
+    widgets.push({ id, span, rows, hidden: Boolean(entry?.hidden) });
   }
 
-  return { widgets };
+  return widgets;
+}
+
+/* INTERIM COMPAT — delete with the edit-mode batch.
+   -------------------------------------------------
+   public/js/modules/dashboard-layout.js still speaks the old flat format and
+   PUTs { widgets: [...] }. Rather than freezing the storage format until that
+   module is rewritten, the old body is wrapped here into a v1 config with a
+   single 'default' board. Nothing else in the codebase writes the flat shape,
+   so when the module starts sending v1 this function, its call in the PUT
+   handler and withLegacyWidgetsAlias() below all go away together. */
+function adaptLegacyDashboardPayload(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+  // Already v1, or not the old shape either — hand it to the validator as-is
+  // and let it decide.
+  if (Array.isArray(input.dashboards) || !Array.isArray(input.widgets)) {
+    return input;
+  }
+
+  return {
+    version: DASHBOARD_CONFIG_VERSION,
+    active: DASHBOARD_DEFAULT_SLUG,
+    dashboards: [
+      {
+        slug: DASHBOARD_DEFAULT_SLUG,
+        name: DASHBOARD_DEFAULT_NAME,
+        widgets: input.widgets,
+      },
+    ],
+  };
+}
+
+/* INTERIM COMPAT — delete with the edit-mode batch.
+   The same module reads result.data.widgets, so GET answers with the v1 object
+   plus a top-level alias of the active board's cards. Documented as deprecated
+   in the @swagger block; nothing new may read it. */
+function withLegacyWidgetsAlias(dashboardConfig) {
+  const active = dashboardConfig.dashboards.find(
+    (board) => board.slug === dashboardConfig.active
+  );
+  return { ...dashboardConfig, widgets: active ? active.widgets : [] };
+}
+
+/* "Give me the defaults back" arrives in two shapes: no boards at all, or the
+   single board the reset button empties. Both clear the stored config. More
+   than one board is left alone — an empty board among several is a named view
+   that happens to show the default cards, and dropping its name would be the
+   opposite of what the user asked for. */
+function isDashboardResetRequest(input) {
+  if (!input || !Array.isArray(input.dashboards)) {
+    return false;
+  }
+  if (input.dashboards.length === 0) {
+    return true;
+  }
+  return (
+    input.dashboards.length === 1 &&
+    Array.isArray(input.dashboards[0]?.widgets) &&
+    input.dashboards[0].widgets.length === 0
+  );
+}
+
+function normalizeDashboardConfig(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return null;
+  }
+  // Strict: version is written by our own code, never typed into a form, so a
+  // string '1' is a bug worth surfacing rather than a value worth coercing.
+  if (input.version !== DASHBOARD_CONFIG_VERSION) {
+    return null;
+  }
+  if (!Array.isArray(input.dashboards)) {
+    return null;
+  }
+  if (
+    input.dashboards.length < 1 ||
+    input.dashboards.length > DASHBOARD_MAX_BOARDS
+  ) {
+    return null;
+  }
+
+  const slugs = new Set();
+  const dashboards = [];
+  for (const entry of input.dashboards) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return null;
+    }
+
+    // Slugs are ids, so they answer to the widget-id rules: lowercase, no
+    // markup, short enough to live in a URL.
+    const slug = String(entry.slug || '').trim();
+    if (!DASHBOARD_WIDGET_ID.test(slug) || slugs.has(slug)) {
+      return null;
+    }
+    slugs.add(slug);
+
+    // The name is what the user typed, so it is trimmed first and then has to
+    // still say something. It is escaped where it is rendered, not here.
+    const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+    if (name.length < 1 || name.length > DASHBOARD_MAX_NAME_LENGTH) {
+      return null;
+    }
+
+    // A board without widgets is the default arrangement under a name, so a
+    // missing list is the same as an empty one. A non-array is not.
+    const widgets = normalizeDashboardWidgets(
+      entry.widgets === undefined || entry.widgets === null ? [] : entry.widgets
+    );
+    if (!widgets) {
+      return null;
+    }
+
+    dashboards.push({ slug, name, widgets });
+  }
+
+  const requested = String(input.active || '').trim();
+  const active = slugs.has(requested) ? requested : dashboards[0].slug;
+
+  return { version: DASHBOARD_CONFIG_VERSION, active, dashboards };
 }
 
 /**
  * @swagger
  * /api/dashboard/layout:
  *   get:
- *     summary: Read the authenticated user's dashboard grid layout
+ *     summary: Read the authenticated user's dashboard configuration
  *     description: >
- *       Returns the widget order, column spans and tile-row heights the user
- *       arranged. widgets is empty when the user has not customised anything,
- *       which means the dashboard renders in its default order.
+ *       Returns the stored configuration in storage format v1: the named
+ *       dashboards the user arranged, each with its widgets in display order,
+ *       and the slug of the active one. An empty dashboards list means nothing
+ *       has been customised and every board renders in its default order — the
+ *       same answer a user without a stored configuration gets.
  *     tags:
  *       - Dashboard
  *     security:
  *       - BearerAuth: []
  *     responses:
  *       200:
- *         description: The stored layout
+ *         description: The stored configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     version:
+ *                       type: integer
+ *                       example: 1
+ *                     active:
+ *                       type: string
+ *                       description: Slug of the dashboard currently shown
+ *                       example: "default"
+ *                     dashboards:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           slug:
+ *                             type: string
+ *                             example: "default"
+ *                           name:
+ *                             type: string
+ *                             example: "Dashboard"
+ *                           widgets:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 id:
+ *                                   type: string
+ *                                   example: "task-runner"
+ *                                 span:
+ *                                   type: integer
+ *                                   description: Width in grid columns, 3 to 12
+ *                                   example: 12
+ *                                 rows:
+ *                                   type: integer
+ *                                   description: Height in tile rows, 3 to 24, or 0 for as tall as the content
+ *                                   example: 0
+ *                                 hidden:
+ *                                   type: boolean
+ *                                   example: false
+ *                     widgets:
+ *                       type: array
+ *                       deprecated: true
+ *                       description: >
+ *                         Deprecated alias for the active dashboard's widgets,
+ *                         kept only until the browser module speaks the
+ *                         named-dashboard format. Read dashboards instead.
+ *                       items:
+ *                         type: object
  *       401:
  *         description: Not authenticated
  */
@@ -10308,11 +10543,28 @@ router.get('/api/dashboard/layout', isAuthenticated, async (req, res) => {
   try {
     const username = req.user && req.user.username;
     if (!username) {
-      return res.json({ success: true, data: { widgets: [] } });
+      return res.json({
+        success: true,
+        data: withLegacyWidgetsAlias(emptyDashboardConfig()),
+      });
     }
 
-    const layout = await documentModel.getDashboardLayout(username);
-    return res.json({ success: true, data: layout || { widgets: [] } });
+    const stored = await documentModel.getDashboardLayout(username);
+    // What was stored was validated on the way in, so it is handed back as it
+    // is. Only the shape is checked: this is an unreleased feature, and a blob
+    // in an older shape is a development leftover that should quietly fall back
+    // to the defaults rather than reach the browser.
+    const dashboardConfig =
+      stored &&
+      stored.version === DASHBOARD_CONFIG_VERSION &&
+      Array.isArray(stored.dashboards)
+        ? stored
+        : emptyDashboardConfig();
+
+    return res.json({
+      success: true,
+      data: withLegacyWidgetsAlias(dashboardConfig),
+    });
   } catch (error) {
     console.error('[ERROR] GET /api/dashboard/layout:', error);
     return res
@@ -10325,21 +10577,94 @@ router.get('/api/dashboard/layout', isAuthenticated, async (req, res) => {
  * @swagger
  * /api/dashboard/layout:
  *   put:
- *     summary: Store or reset the authenticated user's dashboard grid layout
+ *     summary: Store or reset the authenticated user's dashboard configuration
  *     description: >
- *       Accepts a widgets array of {id, span, rows} in display order. Spans are
- *       3 to 12 grid columns; rows are 3 to 24 tile rows, or 0 for a card that
- *       is as tall as its content. Sending an empty widgets array clears the
- *       layout, so the dashboard returns to its default order.
+ *       Takes a complete configuration in storage format v1 and replaces the
+ *       stored one; there is no partial update. Up to 10 dashboards, each with
+ *       a slug, a name of 1 to 60 characters and up to 50 widgets in display
+ *       order. Widget spans are 3 to 12 grid columns; rows are 3 to 24 tile
+ *       rows, or 0 for a card that is as tall as its content. A dashboard
+ *       without widgets shows the default arrangement under its own name.
+ *
+ *       Two payloads reset instead of storing: an empty dashboards array, and a
+ *       single dashboard whose widgets array is empty. Both clear the stored
+ *       configuration, so every board returns to its default order. Emptying
+ *       one board out of several does not reset — that board simply shows the
+ *       defaults and keeps its name.
+ *
+ *       If active names a dashboard that is not in the payload it is replaced
+ *       with the first dashboard's slug rather than rejecting the write.
+ *
+ *       Deprecated: a flat {widgets: [...]} body is still accepted and stored
+ *       as the single 'default' dashboard, until the browser module speaks the
+ *       named-dashboard format. Do not build on it.
  *     tags:
  *       - Dashboard
  *     security:
  *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               version:
+ *                 type: integer
+ *                 enum: [1]
+ *                 example: 1
+ *               active:
+ *                 type: string
+ *                 description: Slug of the dashboard to show
+ *                 example: "default"
+ *               dashboards:
+ *                 type: array
+ *                 maxItems: 10
+ *                 items:
+ *                   type: object
+ *                   required:
+ *                     - slug
+ *                     - name
+ *                   properties:
+ *                     slug:
+ *                       type: string
+ *                       pattern: "^[a-z0-9][a-z0-9-]{0,39}$"
+ *                       example: "default"
+ *                     name:
+ *                       type: string
+ *                       minLength: 1
+ *                       maxLength: 60
+ *                       example: "Dashboard"
+ *                     widgets:
+ *                       type: array
+ *                       maxItems: 50
+ *                       items:
+ *                         type: object
+ *                         required:
+ *                           - id
+ *                           - span
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             pattern: "^[a-z0-9][a-z0-9-]{0,39}$"
+ *                             example: "task-runner"
+ *                           span:
+ *                             type: integer
+ *                             minimum: 3
+ *                             maximum: 12
+ *                             example: 12
+ *                           rows:
+ *                             type: integer
+ *                             description: 3 to 24 tile rows, or 0 for as tall as the content
+ *                             example: 0
+ *                           hidden:
+ *                             type: boolean
+ *                             default: false
  *     responses:
  *       200:
- *         description: Layout stored
+ *         description: Configuration stored or reset
  *       400:
- *         description: Malformed layout
+ *         description: Malformed configuration
  *       401:
  *         description: Not authenticated
  */
@@ -10354,23 +10679,33 @@ router.put(
         return res.json({ success: true, message: 'No user to store against' });
       }
 
-      // An empty list is how the dashboard asks for the default back.
-      if (Array.isArray(req.body?.widgets) && req.body.widgets.length === 0) {
+      // INTERIM COMPAT — delete with the edit-mode batch: the browser still
+      // sends the old flat { widgets: [...] } body, which is wrapped into a v1
+      // config here so both shapes reach the same validator.
+      const payload = adaptLegacyDashboardPayload(req.body);
+
+      // Nothing arranged is not stored as "an empty arrangement": the row is
+      // cleared, so the dashboard falls back to the registry order.
+      if (isDashboardResetRequest(payload)) {
         await documentModel.setDashboardLayout(username, null);
-        return res.json({ success: true, message: 'Dashboard layout reset' });
+        return res.json({
+          success: true,
+          data: withLegacyWidgetsAlias(emptyDashboardConfig()),
+          message: 'Dashboard layout reset',
+        });
       }
 
-      const layout = normalizeDashboardLayout(req.body);
-      if (!layout) {
+      const dashboardConfig = normalizeDashboardConfig(payload);
+      if (!dashboardConfig) {
         return res
           .status(400)
           .json({ success: false, error: 'Invalid dashboard layout' });
       }
 
-      await documentModel.setDashboardLayout(username, layout);
+      await documentModel.setDashboardLayout(username, dashboardConfig);
       return res.json({
         success: true,
-        data: layout,
+        data: withLegacyWidgetsAlias(dashboardConfig),
         message: 'Dashboard layout saved',
       });
     } catch (error) {

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -33,6 +33,7 @@ const quickstartService = require('../services/quickstartService');
 const reconciliationService = require('../services/reconciliationService');
 const scanHealthService = require('../services/scanHealthService');
 const updateCheckService = require('../services/updateCheckService');
+const dashboardStatsService = require('../services/dashboardStatsService');
 const {
   THUMBNAIL_CACHE_DIR,
   getThumbnailCachePath,
@@ -6338,134 +6339,13 @@ router.get('/dashboard', async (req, res) => {
   });
 });
 
+// The payload itself is assembled in dashboardStatsService and cached there:
+// this endpoint is polled by every open dashboard, and rebuilding it per
+// request meant two Paperless-ngx round trips plus a dozen queries each time.
 router.get('/api/dashboard/stats', async (req, res) => {
   try {
-    const [
-      tagCount,
-      correspondentCount,
-      documentCount,
-      rawProcessedDocumentCount,
-      ocrNeededCount,
-      ocrFailedCount,
-      processingFailedCount,
-      metrics,
-      processingTimeStats,
-      tokenDistribution,
-      documentTypes,
-      tokenTrend,
-      recentActivity,
-      languageDistribution,
-      processingStatus,
-    ] = await Promise.all([
-      paperlessService.getTagCount(),
-      paperlessService.getCorrespondentCount(),
-      paperlessService.getEffectiveDocumentCount(),
-      documentModel.getProcessedDocumentsCount(),
-      documentModel.getOcrQueueCount(),
-      documentModel.getOcrFailedCount(),
-      documentModel.getFailedProcessingCount(),
-      documentModel.getMetrics(),
-      documentModel.getProcessingTimeStats(),
-      documentModel.getTokenDistribution(),
-      documentModel.getDocumentTypeStats(),
-      documentModel.getTokenTrend(7),
-      documentModel.getRecentHistoryDocuments(3),
-      documentModel.getLanguageDistribution(5),
-      documentModel.getCurrentProcessingStatus(),
-    ]);
-
-    const processedDocumentCount = rawProcessedDocumentCount;
-    const failedCount = ocrFailedCount + processingFailedCount;
-    const queueBacklog = Math.max(0, ocrNeededCount + failedCount);
-    const processingAttemptCount = processedDocumentCount + failedCount;
-    const processingEfficiencyRate =
-      processingAttemptCount > 0
-        ? Math.round((processedDocumentCount / processingAttemptCount) * 100)
-        : 0;
-    const failedRate =
-      processingAttemptCount > 0
-        ? Math.round((failedCount / processingAttemptCount) * 100)
-        : 0;
-    const processedToday = Number(processingStatus?.processedToday || 0);
-
-    const averagePromptTokens =
-      metrics.length > 0
-        ? Math.round(
-            metrics.reduce((acc, cur) => acc + cur.promptTokens, 0) /
-              metrics.length
-          )
-        : 0;
-    const averageCompletionTokens =
-      metrics.length > 0
-        ? Math.round(
-            metrics.reduce((acc, cur) => acc + cur.completionTokens, 0) /
-              metrics.length
-          )
-        : 0;
-    const averageTotalTokens =
-      metrics.length > 0
-        ? Math.round(
-            metrics.reduce((acc, cur) => acc + cur.totalTokens, 0) /
-              metrics.length
-          )
-        : 0;
-    const tokensOverall =
-      metrics.length > 0
-        ? metrics.reduce((acc, cur) => acc + cur.totalTokens, 0)
-        : 0;
-
-    const normalizedTokenTrend = Array.isArray(tokenTrend)
-      ? tokenTrend.map((entry) => ({
-          day: entry.day,
-          documents: Number(entry.documents || 0),
-          totalTokens: Number(entry.totalTokens || 0),
-        }))
-      : [];
-
-    const normalizedRecentActivity = Array.isArray(recentActivity)
-      ? recentActivity.map((entry) => ({
-          documentId: Number(entry.documentId || 0),
-          title: entry.title || 'Untitled document',
-          correspondent: entry.correspondent || 'Unknown correspondent',
-          createdAt: entry.createdAt,
-          language: entry.language || 'Unknown',
-        }))
-      : [];
-
-    const normalizedLanguageDistribution = Array.isArray(languageDistribution)
-      ? languageDistribution.map((entry) => ({
-          language: entry.language || 'Unknown',
-          count: Number(entry.count || 0),
-        }))
-      : [];
-
-    res.json({
-      success: true,
-      paperless_data: {
-        tagCount,
-        correspondentCount,
-        documentCount,
-        processedDocumentCount,
-        ocrNeededCount,
-        failedCount,
-        queueBacklog,
-        processingEfficiencyRate,
-        failedRate,
-        processedToday,
-        processingTimeStats,
-        tokenDistribution,
-        documentTypes,
-        tokenTrend: normalizedTokenTrend,
-        recentActivity: normalizedRecentActivity,
-        languageDistribution: normalizedLanguageDistribution,
-      },
-      openai_data: {
-        averagePromptTokens,
-        averageCompletionTokens,
-        averageTotalTokens,
-        tokensOverall,
-      },
-    });
+    const { payload, cachedAt } = await dashboardStatsService.getStats();
+    res.json({ ...payload, cachedAt });
   } catch (error) {
     console.error('[ERROR] loading dashboard stats:', error);
     res
@@ -6479,7 +6359,14 @@ router.get('/api/dashboard/stats', async (req, res) => {
  * /api/dashboard/stats:
  *   get:
  *     summary: Get dashboard statistics payload
- *     description: Returns all aggregate counters and chart datasets required by the dashboard UI.
+ *     description: |
+ *       Returns all aggregate counters and chart datasets required by the dashboard UI.
+ *
+ *       The payload is served from an in-memory cache instead of being rebuilt per
+ *       request. It is refreshed in the background (once a minute, plus after every
+ *       scan run) and expires after STATS_CACHE_TTL_SECONDS (default 60). The scan
+ *       loop invalidates it for every document it processes, so figures follow
+ *       processing without polling Paperless-ngx on every request.
  *     tags:
  *       - System
  *       - API
@@ -6493,6 +6380,21 @@ router.get('/api/dashboard/stats', async (req, res) => {
  *           application/json:
  *             schema:
  *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 cachedAt:
+ *                   type: integer
+ *                   format: int64
+ *                   description: >-
+ *                     Epoch milliseconds at which the returned payload was assembled.
+ *                     0 when the assembly time is unknown.
+ *                 paperless_data:
+ *                   type: object
+ *                   description: Aggregate counters and chart datasets.
+ *                 openai_data:
+ *                   type: object
+ *                   description: Token averages and the overall token total.
  *       500:
  *         description: Server error
  */

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -31,6 +31,7 @@ function formatStatus(status) {
 }
 
 const TESTS = {
+  'dashboard-stats-cache': 'test-dashboard-stats-cache.js',
   'document-type-restriction': 'test-document-type-restriction.js',
   'effective-document-count-cache': 'test-effective-document-count-cache.js',
   'failed-reset-all': 'test-failed-reset-all.js',
@@ -137,6 +138,7 @@ const AREAS = {
     'mobile-toolbar-grid',
   ],
   processing: [
+    'dashboard-stats-cache',
     'document-type-restriction',
     'ignore-tags-filter',
     'effective-document-count-cache',

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const mistralOcrService = require('./services/mistralOcrService');
 const ocrAutoProcessService = require('./services/ocrAutoProcessService');
 const reconciliationService = require('./services/reconciliationService');
 const scanHealthService = require('./services/scanHealthService');
+const dashboardStatsService = require('./services/dashboardStatsService');
 const { RUN_STATUS } = scanHealthService;
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
@@ -1074,6 +1075,10 @@ async function scanDocuments(source = 'scheduler') {
         await saveDocumentChanges(doc.id, updateData, analysis, originalData);
         await documentModel.setProcessingStatus(doc.id, doc.title, 'complete');
         scanStats.processed += 1;
+        // The document counters and token figures just changed. Marking the
+        // cache stale costs nothing here; the next dashboard poll pays for the
+        // rebuild, so a long scan does not rebuild once per document.
+        dashboardStatsService.invalidate();
       } catch (error) {
         await documentModel.setProcessingStatus(doc.id, doc.title, 'failed');
         scanStats.failed += 1;
@@ -1109,6 +1114,16 @@ async function scanDocuments(source = 'scheduler') {
     scanControl.source = null;
     scanControl.startedAt = null;
     scanControl.stopRequestedAt = null;
+
+    // Rebuild once the run is over so the first dashboard poll after a scan
+    // reads finished numbers instead of paying for the assembly itself.
+    // Detached: nothing in the scan depends on it, and an unhandled rejection
+    // would take the process down.
+    dashboardStatsService.refresh().catch((error) => {
+      console.debug(
+        `[DASHBOARD-STATS] Refresh after scan failed: ${error.message}`
+      );
+    });
   }
 }
 
@@ -1390,6 +1405,32 @@ async function startScanning() {
         '[RECONCILIATION] Automatic reconciliation is disabled (RECONCILIATION_ENABLED=no).'
       );
     }
+
+    // Dashboard statistics are cached, and the cache is kept warm from here so
+    // no visitor ever waits for the assembly. Armed before the automatic
+    // processing kill-switch below on purpose: the dashboard is served (and
+    // polled) whether or not scanning is enabled.
+    if (isConfigured) {
+      dashboardStatsService.refresh().catch((error) => {
+        console.debug(`[DASHBOARD-STATS] Warmup failed: ${error.message}`);
+      });
+    }
+
+    cron.schedule('* * * * *', async () => {
+      // Never compete with a running scan for the Paperless API — the scan
+      // invalidates the cache per document anyway, and the run end refreshes it.
+      if (scanControl.running) {
+        return;
+      }
+      if (!(await setupService.isConfigured())) {
+        return;
+      }
+      await dashboardStatsService.refresh().catch((error) => {
+        console.debug(
+          `[DASHBOARD-STATS] Scheduled refresh failed: ${error.message}`
+        );
+      });
+    });
 
     if (config.disableAutomaticProcessing === 'yes') {
       scanHealthService.markAutomaticProcessingDisabled();

--- a/server.js
+++ b/server.js
@@ -1082,6 +1082,9 @@ async function scanDocuments(source = 'scheduler') {
       } catch (error) {
         await documentModel.setProcessingStatus(doc.id, doc.title, 'failed');
         scanStats.failed += 1;
+        // A failure moves the failed counter and the failure rate, which the
+        // dashboard shows just as prominently as the successes.
+        dashboardStatsService.invalidate();
         console.error(
           `[ERROR] processing document ${doc.id}: ${error.message}`
         );

--- a/services/dashboardStatsService.js
+++ b/services/dashboardStatsService.js
@@ -1,0 +1,236 @@
+/**
+ * DashboardStatsService
+ *
+ * Assembles the dashboard statistics payload once and serves it from memory.
+ *
+ * Background: /api/dashboard/stats rebuilt everything per request — two
+ * uncached Paperless-ngx round trips (tag and correspondent counts) plus a
+ * dozen SQLite queries, one of which read every row of openai_metrics into
+ * memory just to average it. The dashboard polls that endpoint, and every open
+ * browser tab polls it separately, so the cost scaled with the number of
+ * viewers while the numbers themselves change only when a document is
+ * processed.
+ *
+ * The payload is now built here at most once per TTL, refreshed in the
+ * background, and invalidated by the scan loop when a document actually
+ * changes something. Requests never wait on Paperless-ngx unless the cache is
+ * empty.
+ */
+
+const paperlessService = require('./paperlessService');
+const documentModel = require('../models/document');
+
+// A rebuild that failed (Paperless-ngx down, database locked) must not be
+// retried on every poll — the dashboard polls continuously, and a hard-down
+// backend would turn that into a request storm. Short enough that a recovering
+// backend shows up quickly.
+const FAILURE_RETRY_MS = 10 * 1000;
+
+const DEFAULT_TTL_SECONDS = 60;
+
+class DashboardStatsService {
+  constructor() {
+    this.cache = null;
+    this.cachedAt = 0;
+    this.inFlight = null;
+    this.lastFailureAt = 0;
+  }
+
+  /** Test seam — drops the cached payload so the next call rebuilds. */
+  reset() {
+    this.cache = null;
+    this.cachedAt = 0;
+    this.inFlight = null;
+    this.lastFailureAt = 0;
+  }
+
+  /**
+   * Read from config on every access instead of memoizing: STATS_CACHE_TTL_SECONDS
+   * can be changed at runtime through the settings page, and a value frozen at
+   * first use would keep the old TTL until the next restart.
+   */
+  get ttlMs() {
+    const runtimeConfig = require('../config/config');
+    const seconds = Number(runtimeConfig.statsCacheTTL);
+    return (
+      (Number.isFinite(seconds) && seconds > 0
+        ? seconds
+        : DEFAULT_TTL_SECONDS) * 1000
+    );
+  }
+
+  isFresh() {
+    if (!this.cache) return false;
+    // Serve the last good payload while the failure backoff runs, so a broken
+    // backend costs one attempt per FAILURE_RETRY_MS instead of one per poll.
+    if (Date.now() - this.lastFailureAt < FAILURE_RETRY_MS) return true;
+    return Date.now() - this.cachedAt < this.ttlMs;
+  }
+
+  /**
+   * @param {{force?: boolean}} [options]
+   * @returns {Promise<{payload: object, cachedAt: number}>} cached or freshly built stats
+   */
+  async getStats({ force = false } = {}) {
+    if (!force && this.isFresh()) {
+      return { payload: this.cache, cachedAt: this.cachedAt };
+    }
+
+    // Concurrent viewers (and the background refresh) share one build instead
+    // of each starting their own round of Paperless calls.
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+
+    this.inFlight = this.buildStats()
+      .then((payload) => {
+        this.cache = payload;
+        this.cachedAt = Date.now();
+        this.lastFailureAt = 0;
+        return { payload, cachedAt: this.cachedAt };
+      })
+      .catch((error) => {
+        this.lastFailureAt = Date.now();
+        // Nothing cached yet: the caller has no numbers to show, so let the
+        // route turn this into its 500 instead of inventing zeroes.
+        if (!this.cache) {
+          throw error;
+        }
+        console.warn(
+          '[DASHBOARD-STATS] Rebuild failed, serving the last good payload:',
+          error.message
+        );
+        return { payload: this.cache, cachedAt: this.cachedAt };
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
+
+    return this.inFlight;
+  }
+
+  /** Rebuilds regardless of the TTL. Used by the warmup and the background job. */
+  async refresh() {
+    return this.getStats({ force: true });
+  }
+
+  /**
+   * Marks the cache stale without doing any work, so the next reader rebuilds.
+   * Cheap enough to call once per processed document.
+   */
+  invalidate() {
+    this.cachedAt = 0;
+  }
+
+  /**
+   * Gathers everything the dashboard shows. Kept as a method (not a module
+   * function) so tests can replace it without stubbing every collaborator.
+   *
+   * @returns {Promise<object>} the response body the endpoint returns
+   */
+  async buildStats() {
+    const [
+      tagCount,
+      correspondentCount,
+      documentCount,
+      rawProcessedDocumentCount,
+      ocrNeededCount,
+      ocrFailedCount,
+      processingFailedCount,
+      metricsSummary,
+      processingTimeStats,
+      tokenDistribution,
+      documentTypes,
+      tokenTrend,
+      recentActivity,
+      languageDistribution,
+      processingStatus,
+    ] = await Promise.all([
+      paperlessService.getTagCount(),
+      paperlessService.getCorrespondentCount(),
+      paperlessService.getEffectiveDocumentCount(),
+      documentModel.getProcessedDocumentsCount(),
+      documentModel.getOcrQueueCount(),
+      documentModel.getOcrFailedCount(),
+      documentModel.getFailedProcessingCount(),
+      documentModel.getMetricsSummary(),
+      documentModel.getProcessingTimeStats(),
+      documentModel.getTokenDistribution(),
+      documentModel.getDocumentTypeStats(),
+      documentModel.getTokenTrend(7),
+      documentModel.getRecentHistoryDocuments(3),
+      documentModel.getLanguageDistribution(5),
+      documentModel.getCurrentProcessingStatus(),
+    ]);
+
+    const processedDocumentCount = rawProcessedDocumentCount;
+    const failedCount = ocrFailedCount + processingFailedCount;
+    const queueBacklog = Math.max(0, ocrNeededCount + failedCount);
+    const processingAttemptCount = processedDocumentCount + failedCount;
+    const processingEfficiencyRate =
+      processingAttemptCount > 0
+        ? Math.round((processedDocumentCount / processingAttemptCount) * 100)
+        : 0;
+    const failedRate =
+      processingAttemptCount > 0
+        ? Math.round((failedCount / processingAttemptCount) * 100)
+        : 0;
+    const processedToday = Number(processingStatus?.processedToday || 0);
+
+    const normalizedTokenTrend = Array.isArray(tokenTrend)
+      ? tokenTrend.map((entry) => ({
+          day: entry.day,
+          documents: Number(entry.documents || 0),
+          totalTokens: Number(entry.totalTokens || 0),
+        }))
+      : [];
+
+    const normalizedRecentActivity = Array.isArray(recentActivity)
+      ? recentActivity.map((entry) => ({
+          documentId: Number(entry.documentId || 0),
+          title: entry.title || 'Untitled document',
+          correspondent: entry.correspondent || 'Unknown correspondent',
+          createdAt: entry.createdAt,
+          language: entry.language || 'Unknown',
+        }))
+      : [];
+
+    const normalizedLanguageDistribution = Array.isArray(languageDistribution)
+      ? languageDistribution.map((entry) => ({
+          language: entry.language || 'Unknown',
+          count: Number(entry.count || 0),
+        }))
+      : [];
+
+    return {
+      success: true,
+      paperless_data: {
+        tagCount,
+        correspondentCount,
+        documentCount,
+        processedDocumentCount,
+        ocrNeededCount,
+        failedCount,
+        queueBacklog,
+        processingEfficiencyRate,
+        failedRate,
+        processedToday,
+        processingTimeStats,
+        tokenDistribution,
+        documentTypes,
+        tokenTrend: normalizedTokenTrend,
+        recentActivity: normalizedRecentActivity,
+        languageDistribution: normalizedLanguageDistribution,
+      },
+      openai_data: {
+        averagePromptTokens: metricsSummary.averagePromptTokens,
+        averageCompletionTokens: metricsSummary.averageCompletionTokens,
+        averageTotalTokens: metricsSummary.averageTotalTokens,
+        tokensOverall: metricsSummary.tokensOverall,
+      },
+    };
+  }
+}
+
+module.exports = new DashboardStatsService();
+module.exports.FAILURE_RETRY_MS = FAILURE_RETRY_MS;

--- a/services/dashboardStatsService.js
+++ b/services/dashboardStatsService.js
@@ -33,7 +33,13 @@ class DashboardStatsService {
     this.cache = null;
     this.cachedAt = 0;
     this.inFlight = null;
+    this.inFlightGeneration = 0;
+    this.cacheGeneration = 0;
     this.lastFailureAt = 0;
+    // Bumped by every invalidate(). A build carries the generation it started
+    // in, so a build that began before an invalidation can be recognised as
+    // describing a world that no longer exists — see getStats().
+    this.generation = 0;
   }
 
   /** Test seam — drops the cached payload so the next call rebuilds. */
@@ -41,7 +47,10 @@ class DashboardStatsService {
     this.cache = null;
     this.cachedAt = 0;
     this.inFlight = null;
+    this.inFlightGeneration = 0;
+    this.cacheGeneration = 0;
     this.lastFailureAt = 0;
+    this.generation = 0;
   }
 
   /**
@@ -63,7 +72,13 @@ class DashboardStatsService {
     if (!this.cache) return false;
     // Serve the last good payload while the failure backoff runs, so a broken
     // backend costs one attempt per FAILURE_RETRY_MS instead of one per poll.
+    // This outranks the generation check below on purpose: a backend that
+    // cannot answer a rebuild cannot answer a rebuild for a changed document
+    // either, so retrying per poll would only add load.
     if (Date.now() - this.lastFailureAt < FAILURE_RETRY_MS) return true;
+    // Something was invalidated after these numbers were assembled. They are
+    // still worth serving while the rebuild runs, but they are not fresh.
+    if (this.cacheGeneration !== this.generation) return false;
     return Date.now() - this.cachedAt < this.ttlMs;
   }
 
@@ -77,15 +92,33 @@ class DashboardStatsService {
     }
 
     // Concurrent viewers (and the background refresh) share one build instead
-    // of each starting their own round of Paperless calls.
-    if (this.inFlight) {
+    // of each starting their own round of Paperless calls — but only while that
+    // build still describes the current state. A build that began before an
+    // invalidation is already known to be answering the wrong question, so
+    // joining it would hand the caller the very payload the invalidation
+    // rejected. That is what made the end-of-scan refresh a no-op.
+    if (this.inFlight && this.inFlightGeneration === this.generation) {
       return this.inFlight;
     }
 
-    this.inFlight = this.buildStats()
+    const startedAt = this.generation;
+    const build = this.buildStats()
       .then((payload) => {
+        const builtAt = Date.now();
+        // Two builds can be in flight after an invalidation, and the older one
+        // may well finish last. Serve its numbers to whoever waited on it, but
+        // do not let them overwrite a newer picture.
+        if (this.cache && startedAt < this.cacheGeneration) {
+          return { payload, cachedAt: builtAt };
+        }
         this.cache = payload;
-        this.cachedAt = Date.now();
+        this.cachedAt = builtAt;
+        // The state these numbers describe. If something was invalidated while
+        // Paperless-ngx was answering, this is already behind and isFresh()
+        // sends the next reader back for a rebuild. The payload is still kept
+        // and served in the meantime — dropping it would leave a fast scan
+        // rebuilding from scratch on every poll with nothing ever cached.
+        this.cacheGeneration = startedAt;
         this.lastFailureAt = 0;
         return { payload, cachedAt: this.cachedAt };
       })
@@ -103,13 +136,22 @@ class DashboardStatsService {
         return { payload: this.cache, cachedAt: this.cachedAt };
       })
       .finally(() => {
-        this.inFlight = null;
+        // A build superseded by a newer one must not clear the newer one's slot.
+        if (this.inFlight === build) {
+          this.inFlight = null;
+        }
       });
 
-    return this.inFlight;
+    this.inFlight = build;
+    this.inFlightGeneration = startedAt;
+    return build;
   }
 
-  /** Rebuilds regardless of the TTL. Used by the warmup and the background job. */
+  /**
+   * Rebuilds regardless of the TTL. Used by the warmup and the background job.
+   * Joins a build that is already running for the current generation — that one
+   * will report the same state — but never one that predates an invalidation.
+   */
   async refresh() {
     return this.getStats({ force: true });
   }
@@ -117,9 +159,16 @@ class DashboardStatsService {
   /**
    * Marks the cache stale without doing any work, so the next reader rebuilds.
    * Cheap enough to call once per processed document.
+   *
+   * Bumping the generation is what makes this survive a concurrent build: the
+   * scan invalidates while the dashboard's poll may already be assembling a
+   * payload, and without the bump that payload would land afterwards and be
+   * stamped fresh, burying the change for a full TTL. cachedAt is deliberately
+   * left alone — it says when the numbers currently on screen were assembled,
+   * which is still true.
    */
   invalidate() {
-    this.cachedAt = 0;
+    this.generation += 1;
   }
 
   /**

--- a/services/ocrAutoProcessService.js
+++ b/services/ocrAutoProcessService.js
@@ -11,6 +11,7 @@ const config = require('../config/config');
 const paperlessService = require('./paperlessService');
 const mistralOcrService = require('./mistralOcrService');
 const documentModel = require('../models/document');
+const dashboardStatsService = require('./dashboardStatsService');
 
 const DEFAULT_INTERVAL = '*/15 * * * *';
 const DEFAULT_BATCH_SIZE = 10;
@@ -159,6 +160,9 @@ class OcrAutoProcessService {
             autoAnalyze,
           });
           processed += 1;
+          // This queue drains on its own cron, so nothing else tells the
+          // dashboard that the document counters just moved.
+          dashboardStatsService.invalidate();
         } catch (error) {
           // processQueueItem() already moved the item out of 'pending' and
           // recorded the failure, so the next run will not pick it up again.

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1119,6 +1119,23 @@ class PaperlessService {
     return filteredDocuments;
   }
 
+  /**
+   * Stores a computed effective document count and returns it, so every exit
+   * of getEffectiveDocumentCount() populates the cache the same way.
+   *
+   * @param {string} cacheKey
+   * @param {number} count
+   * @returns {number} the count that was cached
+   */
+  cacheEffectiveCount(cacheKey, count) {
+    this._effectiveCountCache = {
+      key: cacheKey,
+      count,
+      expiresAt: Date.now() + this._effectiveCountCacheTtlMs,
+    };
+    return count;
+  }
+
   async getEffectiveDocumentCount() {
     const shouldFilterByTags =
       process.env.PROCESS_PREDEFINED_DOCUMENTS === 'yes';
@@ -1141,14 +1158,17 @@ class PaperlessService {
     let includeTagIds = [];
     let excludeTagIds = [];
 
+    // "Nothing matches" is a result like any other and must be cached too —
+    // otherwise these two paths re-resolve the tag list on every call, which is
+    // exactly the per-request Paperless traffic the cache exists to avoid.
     if (shouldFilterByTags) {
       if (includeTagNames.length === 0) {
-        return 0;
+        return this.cacheEffectiveCount(cacheKey, 0);
       }
 
       includeTagIds = await this.resolveTagIdsByName(includeTagNames);
       if (includeTagIds.length === 0) {
-        return 0;
+        return this.cacheEffectiveCount(cacheKey, 0);
       }
     }
 
@@ -1191,13 +1211,7 @@ class PaperlessService {
         }
       }
 
-      this._effectiveCountCache = {
-        key: cacheKey,
-        count: effectiveCount,
-        expiresAt: Date.now() + this._effectiveCountCacheTtlMs,
-      };
-
-      return effectiveCount;
+      return this.cacheEffectiveCount(cacheKey, effectiveCount);
     } catch (error) {
       console.error(
         '[ERROR] fetching effective document count:',

--- a/tests/test-dashboard-layout-validation.js
+++ b/tests/test-dashboard-layout-validation.js
@@ -6,10 +6,9 @@
  * is the only thing standing between a hostile payload and the database. It has
  * to reject anything it cannot vouch for rather than store it half-checked.
  *
- * The helpers around it are checked here too: the interim adapter that still
- * accepts the old flat body, the deprecated widgets alias the browser reads,
- * and the reset detection that decides when a payload clears the row instead of
- * filling it.
+ * The helpers around it are checked here too: the reset detection that decides
+ * when a payload clears the row instead of filling it, and the empty
+ * configuration both the reset and an unarranged dashboard answer with.
  *
  * All of them are read out of the route file instead of being copied here:
  * a copy would keep passing after the real ones changed.
@@ -34,17 +33,13 @@ assert.ok(
 
 const {
   normalizeDashboardConfig,
-  adaptLegacyDashboardPayload,
   isDashboardResetRequest,
-  withLegacyWidgetsAlias,
   emptyDashboardConfig,
 } = new Function(
   `${source.slice(start, end + 2)}
    return {
      normalizeDashboardConfig,
-     adaptLegacyDashboardPayload,
      isDashboardResetRequest,
-     withLegacyWidgetsAlias,
      emptyDashboardConfig,
    };`
 )();
@@ -272,7 +267,7 @@ const accepted = [
   },
   {
     label:
-      'unknown top-level properties being dropped, the deprecated alias included',
+      'unknown top-level properties being dropped, a stray widget list among them',
     input: config({ theme: 'dark', widgets: [widget({ id: 'smuggled' })] }),
     expect: (result) =>
       assert.deepStrictEqual(Object.keys(result), [
@@ -442,46 +437,9 @@ const rejected = [
   },
 ];
 
-/* --- the interim compat layer, deleted with the edit-mode batch ------------ */
+/* --- resetting, and the answer a dashboard nobody arranged gets ------------ */
 
-const compat = [
-  {
-    label: 'the old flat body wrapped into one default dashboard',
-    run: () => {
-      const adapted = adaptLegacyDashboardPayload({
-        widgets: [{ id: 'entities', span: 4, rows: 0 }],
-      });
-      const result = normalizeDashboardConfig(adapted);
-      assert.ok(result, 'the wrapped body should validate');
-      assert.strictEqual(result.active, 'default');
-      assert.strictEqual(result.dashboards.length, 1);
-      assert.strictEqual(result.dashboards[0].slug, 'default');
-      assert.strictEqual(result.dashboards[0].widgets[0].id, 'entities');
-    },
-  },
-  {
-    label: 'a v1 body handed through the adapter untouched',
-    run: () => {
-      const input = config();
-      assert.strictEqual(adaptLegacyDashboardPayload(input), input);
-    },
-  },
-  {
-    label: 'a body that is neither shape left for the validator to reject',
-    run: () => {
-      const input = { nonsense: true };
-      assert.strictEqual(adaptLegacyDashboardPayload(input), input);
-      assert.strictEqual(normalizeDashboardConfig(input), null);
-    },
-  },
-  {
-    label: 'the old flat reset arriving as a reset',
-    run: () =>
-      assert.strictEqual(
-        isDashboardResetRequest(adaptLegacyDashboardPayload({ widgets: [] })),
-        true
-      ),
-  },
+const helpers = [
   {
     label: 'an empty dashboards list read as a reset',
     run: () =>
@@ -524,37 +482,13 @@ const compat = [
     },
   },
   {
-    label: 'the deprecated alias carrying the active dashboard cards',
-    run: () => {
-      const aliased = withLegacyWidgetsAlias(
-        normalizeDashboardConfig(
-          config({
-            active: 'work',
-            dashboards: [
-              board({}),
-              board({
-                slug: 'work',
-                name: 'Work',
-                widgets: [widget({ id: 'entities', span: 4 })],
-              }),
-            ],
-          })
-        )
-      );
-      assert.strictEqual(aliased.widgets.length, 1);
-      assert.strictEqual(aliased.widgets[0].id, 'entities');
-      assert.strictEqual(aliased.dashboards.length, 2);
-    },
-  },
-  {
-    label: 'the alias empty when nothing is stored',
-    run: () => {
-      const aliased = withLegacyWidgetsAlias(emptyDashboardConfig());
-      assert.deepStrictEqual(aliased.widgets, []);
-      assert.deepStrictEqual(aliased.dashboards, []);
-      assert.strictEqual(aliased.version, 1);
-      assert.strictEqual(aliased.active, 'default');
-    },
+    label: 'the empty configuration a reset and an untouched user both get',
+    run: () =>
+      assert.deepStrictEqual(emptyDashboardConfig(), {
+        version: 1,
+        active: 'default',
+        dashboards: [],
+      }),
   },
 ];
 
@@ -586,7 +520,7 @@ for (const { label, input } of rejected) {
   }
 }
 
-for (const { label, run } of compat) {
+for (const { label, run } of helpers) {
   try {
     run();
     console.log(`  ✓ ${label}`);

--- a/tests/test-dashboard-layout-validation.js
+++ b/tests/test-dashboard-layout-validation.js
@@ -1,13 +1,18 @@
 /**
- * Guards the dashboard layout validator in routes/setup.js.
+ * Guards the dashboard configuration validator in routes/setup.js.
  *
- * PUT /api/dashboard/layout takes a grid arrangement straight from the browser
- * and stores it as JSON on the user row, so normalizeDashboardLayout() is the
- * only thing standing between a hostile payload and the database. It has to
- * reject anything it cannot vouch for rather than store it half-checked.
+ * PUT /api/dashboard/layout takes a set of named dashboards straight from the
+ * browser and stores it as JSON on the user row, so normalizeDashboardConfig()
+ * is the only thing standing between a hostile payload and the database. It has
+ * to reject anything it cannot vouch for rather than store it half-checked.
  *
- * The validator is read out of the route file instead of being copied here:
- * a copy would keep passing after the real one changed.
+ * The helpers around it are checked here too: the interim adapter that still
+ * accepts the old flat body, the deprecated widgets alias the browser reads,
+ * and the reset detection that decides when a payload clears the row instead of
+ * filling it.
+ *
+ * All of them are read out of the route file instead of being copied here:
+ * a copy would keep passing after the real ones changed.
  */
 
 const assert = require('assert');
@@ -20,129 +25,535 @@ const source = fs.readFileSync(ROUTE_FILE, 'utf8');
 const start = source.indexOf('const DASHBOARD_WIDGET_ID');
 const end = source.indexOf(
   '\n}',
-  source.indexOf('function normalizeDashboardLayout')
+  source.indexOf('function normalizeDashboardConfig')
 );
 assert.ok(
   start !== -1 && end !== -1 && end > start,
-  'Could not find normalizeDashboardLayout in routes/setup.js — did it move or get renamed?'
+  'Could not find normalizeDashboardConfig in routes/setup.js — did it move or get renamed?'
 );
 
-const normalizeDashboardLayout = new Function(
-  `${source.slice(start, end + 2)}\nreturn normalizeDashboardLayout;`
+const {
+  normalizeDashboardConfig,
+  adaptLegacyDashboardPayload,
+  isDashboardResetRequest,
+  withLegacyWidgetsAlias,
+  emptyDashboardConfig,
+} = new Function(
+  `${source.slice(start, end + 2)}
+   return {
+     normalizeDashboardConfig,
+     adaptLegacyDashboardPayload,
+     isDashboardResetRequest,
+     withLegacyWidgetsAlias,
+     emptyDashboardConfig,
+   };`
 )();
 
-const valid = { id: 'task-runner', span: 6, rows: 6 };
-const widget = (overrides) => ({ ...valid, ...overrides });
+const widget = (overrides) => ({
+  id: 'task-runner',
+  span: 6,
+  rows: 6,
+  ...overrides,
+});
+const board = (overrides) => ({
+  slug: 'default',
+  name: 'Dashboard',
+  widgets: [widget({})],
+  ...overrides,
+});
+const config = (overrides) => ({
+  version: 1,
+  active: 'default',
+  dashboards: [board({})],
+  ...overrides,
+});
+const boards = (count) =>
+  Array.from({ length: count }, (unused, index) =>
+    board({ slug: `board-${index}`, name: `Board ${index}` })
+  );
+
+/* --- what a stored configuration may look like ---------------------------- */
 
 const accepted = [
   {
-    label: 'a plain layout',
-    input: { widgets: [widget({}), widget({ id: 'entities', span: 3 })] },
+    label: 'a configuration with two named dashboards',
+    input: config({
+      active: 'work',
+      dashboards: [
+        board({}),
+        board({
+          slug: 'work',
+          name: 'Work',
+          widgets: [widget({ id: 'entities', span: 3, rows: 0 })],
+        }),
+      ],
+    }),
     expect: (result) => {
-      assert.strictEqual(result.widgets.length, 2);
-      assert.deepStrictEqual(result.widgets[0], {
-        id: 'task-runner',
-        span: 6,
-        rows: 6,
+      assert.strictEqual(result.version, 1);
+      assert.strictEqual(result.active, 'work');
+      assert.strictEqual(result.dashboards.length, 2);
+      assert.deepStrictEqual(result.dashboards[1], {
+        slug: 'work',
+        name: 'Work',
+        widgets: [{ id: 'entities', span: 3, rows: 0, hidden: false }],
       });
     },
   },
   {
-    label: 'rows 0 meaning "as tall as the content"',
-    input: { widgets: [widget({ rows: 0 })] },
-    expect: (result) => assert.strictEqual(result.widgets[0].rows, 0),
+    label: 'an active slug no dashboard answers to, falling back to the first',
+    input: config({ active: 'deleted-board' }),
+    expect: (result) => assert.strictEqual(result.active, 'default'),
   },
   {
-    label: 'missing rows defaulting to 0',
-    input: { widgets: [{ id: 'entities', span: 4 }] },
-    expect: (result) => assert.strictEqual(result.widgets[0].rows, 0),
+    label: 'a missing active slug, falling back to the first',
+    input: (() => {
+      const input = config();
+      delete input.active;
+      return input;
+    })(),
+    expect: (result) => assert.strictEqual(result.active, 'default'),
+  },
+  {
+    label: 'hidden defaulting to false when the card does not mention it',
+    input: config(),
+    expect: (result) =>
+      assert.strictEqual(result.dashboards[0].widgets[0].hidden, false),
+  },
+  {
+    label: 'hidden coerced to a boolean rather than stored as it arrived',
+    input: config({
+      dashboards: [board({ widgets: [widget({ hidden: 'yes' })] })],
+    }),
+    expect: (result) =>
+      assert.strictEqual(result.dashboards[0].widgets[0].hidden, true),
   },
   {
     label: 'numeric strings from a form',
-    input: { widgets: [widget({ span: '6', rows: '6' })] },
+    input: config({
+      dashboards: [board({ widgets: [widget({ span: '6', rows: '6' })] })],
+    }),
     expect: (result) => {
-      assert.strictEqual(result.widgets[0].span, 6);
-      assert.strictEqual(result.widgets[0].rows, 6);
+      assert.strictEqual(result.dashboards[0].widgets[0].span, 6);
+      assert.strictEqual(result.dashboards[0].widgets[0].rows, 6);
     },
+  },
+  {
+    label: 'rows 0 meaning "as tall as the content"',
+    input: config({
+      dashboards: [board({ widgets: [widget({ rows: 0 })] })],
+    }),
+    expect: (result) =>
+      assert.strictEqual(result.dashboards[0].widgets[0].rows, 0),
+  },
+  {
+    label: 'missing rows defaulting to 0',
+    input: config({
+      dashboards: [board({ widgets: [{ id: 'entities', span: 4 }] })],
+    }),
+    expect: (result) =>
+      assert.strictEqual(result.dashboards[0].widgets[0].rows, 0),
   },
   {
     label: 'the full grid width and the tallest tile',
-    input: { widgets: [widget({ span: 12, rows: 24 })] },
+    input: config({
+      dashboards: [board({ widgets: [widget({ span: 12, rows: 24 })] })],
+    }),
     expect: (result) => {
-      assert.strictEqual(result.widgets[0].span, 12);
-      assert.strictEqual(result.widgets[0].rows, 24);
+      assert.strictEqual(result.dashboards[0].widgets[0].span, 12);
+      assert.strictEqual(result.dashboards[0].widgets[0].rows, 24);
     },
   },
   {
-    label: 'unknown properties being dropped rather than stored',
-    input: {
-      widgets: [{ ...valid, evil: '<script>', nested: { a: 1 } }],
-    },
+    label: 'the card order it was sent in',
+    input: config({
+      dashboards: [
+        board({
+          widgets: [
+            widget({ id: 'entities' }),
+            widget({ id: 'task-runner' }),
+            widget({ id: 'language-mix' }),
+          ],
+        }),
+      ],
+    }),
     expect: (result) =>
-      assert.deepStrictEqual(Object.keys(result.widgets[0]), [
+      assert.deepStrictEqual(
+        result.dashboards[0].widgets.map((entry) => entry.id),
+        ['entities', 'task-runner', 'language-mix']
+      ),
+  },
+  {
+    label: 'a dashboard without widgets, which shows the default arrangement',
+    input: config({ dashboards: [{ slug: 'default', name: 'Dashboard' }] }),
+    expect: (result) =>
+      assert.deepStrictEqual(result.dashboards[0].widgets, []),
+  },
+  {
+    label: 'an empty widget list under a name',
+    input: config({ dashboards: [board({ widgets: [] })] }),
+    expect: (result) =>
+      assert.deepStrictEqual(result.dashboards[0].widgets, []),
+  },
+  {
+    label: 'the same card on two dashboards',
+    input: config({
+      dashboards: [board({}), board({ slug: 'work', name: 'Work' })],
+    }),
+    expect: (result) => {
+      assert.strictEqual(result.dashboards[0].widgets[0].id, 'task-runner');
+      assert.strictEqual(result.dashboards[1].widgets[0].id, 'task-runner');
+    },
+  },
+  {
+    label: 'a name with padding around it, trimmed',
+    input: config({ dashboards: [board({ name: '  Work  ' })] }),
+    expect: (result) => assert.strictEqual(result.dashboards[0].name, 'Work'),
+  },
+  {
+    label: 'the shortest and the longest name allowed',
+    input: config({
+      dashboards: [
+        board({ name: 'W' }),
+        board({ slug: 'long', name: 'n'.repeat(60) }),
+      ],
+    }),
+    expect: (result) => {
+      assert.strictEqual(result.dashboards[0].name, 'W');
+      assert.strictEqual(result.dashboards[1].name.length, 60);
+    },
+  },
+  {
+    label: 'as many dashboards as a user may keep',
+    input: config({ active: 'board-0', dashboards: boards(10) }),
+    expect: (result) => assert.strictEqual(result.dashboards.length, 10),
+  },
+  {
+    label: 'as many cards as a dashboard may hold',
+    input: config({
+      dashboards: [
+        board({
+          widgets: Array.from({ length: 50 }, (unused, index) =>
+            widget({ id: `w-${index}` })
+          ),
+        }),
+      ],
+    }),
+    expect: (result) =>
+      assert.strictEqual(result.dashboards[0].widgets.length, 50),
+  },
+  {
+    label: 'unknown card properties being dropped rather than stored',
+    input: config({
+      dashboards: [
+        board({
+          widgets: [widget({ evil: '<script>', nested: { a: 1 } })],
+        }),
+      ],
+    }),
+    expect: (result) =>
+      assert.deepStrictEqual(Object.keys(result.dashboards[0].widgets[0]), [
         'id',
         'span',
         'rows',
+        'hidden',
+      ]),
+  },
+  {
+    label: 'unknown dashboard properties being dropped',
+    input: config({
+      dashboards: [board({ icon: '<img onerror=alert(1)>', owner: 'root' })],
+    }),
+    expect: (result) =>
+      assert.deepStrictEqual(Object.keys(result.dashboards[0]), [
+        'slug',
+        'name',
+        'widgets',
+      ]),
+  },
+  {
+    label:
+      'unknown top-level properties being dropped, the deprecated alias included',
+    input: config({ theme: 'dark', widgets: [widget({ id: 'smuggled' })] }),
+    expect: (result) =>
+      assert.deepStrictEqual(Object.keys(result), [
+        'version',
+        'active',
+        'dashboards',
       ]),
   },
 ];
 
+/* --- what must never reach the database ----------------------------------- */
+
 const rejected = [
   { label: 'no body at all', input: null },
-  { label: 'a body without widgets', input: {} },
-  { label: 'widgets that is not an array', input: { widgets: 'all of them' } },
+  { label: 'a body that is an array', input: [] },
+  { label: 'a body without a version', input: { dashboards: [board({})] } },
+  { label: 'a version from the future', input: config({ version: 2 }) },
   {
-    label: 'a duplicate widget id',
-    input: { widgets: [widget({}), widget({})] },
+    label: 'a version that is a string, which is a bug and not a form value',
+    input: config({ version: '1' }),
   },
-  { label: 'an empty id', input: { widgets: [widget({ id: '' })] } },
+  { label: 'a body without dashboards', input: { version: 1 } },
   {
-    label: 'an id with markup in it',
-    input: { widgets: [widget({ id: '<script>' })] },
-  },
-  {
-    label: 'an id with an underscore',
-    input: { widgets: [widget({ id: 'task_runner' })] },
+    label: 'dashboards that is not an array',
+    input: config({ dashboards: 'all of them' }),
   },
   {
-    label: 'an id starting with a dash',
-    input: { widgets: [widget({ id: '-runner' })] },
+    label: 'an empty dashboards list, which is a reset and not a layout',
+    input: config({ dashboards: [] }),
   },
   {
-    label: 'an id longer than 40 characters',
-    input: { widgets: [widget({ id: 'a'.repeat(41) })] },
+    label: 'more dashboards than a user may keep',
+    input: config({ dashboards: boards(11) }),
+  },
+  {
+    label: 'a dashboard entry that is not an object',
+    input: config({ dashboards: [null] }),
+  },
+  {
+    label: 'a dashboard entry that is an array',
+    input: config({ dashboards: [[]] }),
+  },
+  {
+    label: 'two dashboards with the same slug',
+    input: config({ dashboards: [board({}), board({ name: 'Copy' })] }),
+  },
+  {
+    label: 'an empty slug',
+    input: config({ dashboards: [board({ slug: '' })] }),
+  },
+  {
+    label: 'a slug with markup in it',
+    input: config({ dashboards: [board({ slug: '<script>' })] }),
+  },
+  {
+    label: 'a slug with an uppercase letter',
+    input: config({ dashboards: [board({ slug: 'Default' })] }),
+  },
+  {
+    label: 'a slug longer than 40 characters',
+    input: config({ dashboards: [board({ slug: 'a'.repeat(41) })] }),
+  },
+  {
+    label: 'a name that is only whitespace',
+    input: config({ dashboards: [board({ name: '   ' })] }),
+  },
+  {
+    label: 'a name of 61 characters',
+    input: config({ dashboards: [board({ name: 'n'.repeat(61) })] }),
+  },
+  {
+    label: 'a name that is not a string',
+    input: config({ dashboards: [board({ name: 42 })] }),
+  },
+  {
+    label: 'widgets that is not an array',
+    input: config({ dashboards: [board({ widgets: 'all of them' })] }),
+  },
+  {
+    label: 'a duplicate card id on one dashboard',
+    input: config({
+      dashboards: [board({ widgets: [widget({}), widget({})] })],
+    }),
+  },
+  {
+    label: 'an empty card id',
+    input: config({ dashboards: [board({ widgets: [widget({ id: '' })] })] }),
+  },
+  {
+    label: 'a card id with markup in it',
+    input: config({
+      dashboards: [board({ widgets: [widget({ id: '<script>' })] })],
+    }),
+  },
+  {
+    label: 'a card id with an underscore',
+    input: config({
+      dashboards: [board({ widgets: [widget({ id: 'task_runner' })] })],
+    }),
+  },
+  {
+    label: 'a card id starting with a dash',
+    input: config({
+      dashboards: [board({ widgets: [widget({ id: '-runner' })] })],
+    }),
+  },
+  {
+    label: 'a card id longer than 40 characters',
+    input: config({
+      dashboards: [board({ widgets: [widget({ id: 'a'.repeat(41) })] })],
+    }),
   },
   {
     label: 'a span below the minimum',
-    input: { widgets: [widget({ span: 2 })] },
+    input: config({ dashboards: [board({ widgets: [widget({ span: 2 })] })] }),
   },
   {
     label: 'a span wider than the grid',
-    input: { widgets: [widget({ span: 13 })] },
+    input: config({ dashboards: [board({ widgets: [widget({ span: 13 })] })] }),
   },
-  { label: 'a missing span', input: { widgets: [{ id: 'entities' }] } },
+  {
+    label: 'a missing span',
+    input: config({ dashboards: [board({ widgets: [{ id: 'entities' }] })] }),
+  },
   {
     label: 'a non-numeric span',
-    input: { widgets: [widget({ span: 'wide' })] },
+    input: config({
+      dashboards: [board({ widgets: [widget({ span: 'wide' })] })],
+    }),
   },
   {
     label: 'more rows than a tile may have',
-    input: { widgets: [widget({ rows: 25 })] },
+    input: config({ dashboards: [board({ widgets: [widget({ rows: 25 })] })] }),
   },
   {
     label: 'fewer rows than a card can show anything in',
-    input: { widgets: [widget({ rows: 2 })] },
+    input: config({ dashboards: [board({ widgets: [widget({ rows: 2 })] })] }),
   },
   {
     label: 'a negative row count',
-    input: { widgets: [widget({ rows: -4 })] },
+    input: config({ dashboards: [board({ widgets: [widget({ rows: -4 })] })] }),
   },
   {
-    label: 'more widgets than the dashboard could ever hold',
-    input: {
-      widgets: Array.from({ length: 51 }, (unused, index) =>
-        widget({ id: `w-${index}` })
+    label: 'more cards than a dashboard could ever hold',
+    input: config({
+      dashboards: [
+        board({
+          widgets: Array.from({ length: 51 }, (unused, index) =>
+            widget({ id: `w-${index}` })
+          ),
+        }),
+      ],
+    }),
+  },
+  {
+    label: 'a bad card on the second dashboard, taking the whole write down',
+    input: config({
+      dashboards: [
+        board({}),
+        board({
+          slug: 'work',
+          name: 'Work',
+          widgets: [widget({ span: 99 })],
+        }),
+      ],
+    }),
+  },
+];
+
+/* --- the interim compat layer, deleted with the edit-mode batch ------------ */
+
+const compat = [
+  {
+    label: 'the old flat body wrapped into one default dashboard',
+    run: () => {
+      const adapted = adaptLegacyDashboardPayload({
+        widgets: [{ id: 'entities', span: 4, rows: 0 }],
+      });
+      const result = normalizeDashboardConfig(adapted);
+      assert.ok(result, 'the wrapped body should validate');
+      assert.strictEqual(result.active, 'default');
+      assert.strictEqual(result.dashboards.length, 1);
+      assert.strictEqual(result.dashboards[0].slug, 'default');
+      assert.strictEqual(result.dashboards[0].widgets[0].id, 'entities');
+    },
+  },
+  {
+    label: 'a v1 body handed through the adapter untouched',
+    run: () => {
+      const input = config();
+      assert.strictEqual(adaptLegacyDashboardPayload(input), input);
+    },
+  },
+  {
+    label: 'a body that is neither shape left for the validator to reject',
+    run: () => {
+      const input = { nonsense: true };
+      assert.strictEqual(adaptLegacyDashboardPayload(input), input);
+      assert.strictEqual(normalizeDashboardConfig(input), null);
+    },
+  },
+  {
+    label: 'the old flat reset arriving as a reset',
+    run: () =>
+      assert.strictEqual(
+        isDashboardResetRequest(adaptLegacyDashboardPayload({ widgets: [] })),
+        true
       ),
+  },
+  {
+    label: 'an empty dashboards list read as a reset',
+    run: () =>
+      assert.strictEqual(isDashboardResetRequest({ dashboards: [] }), true),
+  },
+  {
+    label: 'a single emptied dashboard read as a reset',
+    run: () =>
+      assert.strictEqual(
+        isDashboardResetRequest(
+          config({ dashboards: [board({ widgets: [] })] })
+        ),
+        true
+      ),
+  },
+  {
+    label: 'one emptied dashboard among several left alone',
+    run: () =>
+      assert.strictEqual(
+        isDashboardResetRequest(
+          config({
+            dashboards: [
+              board({ widgets: [] }),
+              board({ slug: 'work', name: 'Work' }),
+            ],
+          })
+        ),
+        false
+      ),
+  },
+  {
+    label: 'an arrangement not read as a reset',
+    run: () => assert.strictEqual(isDashboardResetRequest(config()), false),
+  },
+  {
+    label: 'a body without dashboards not read as a reset',
+    run: () => {
+      assert.strictEqual(isDashboardResetRequest(null), false);
+      assert.strictEqual(isDashboardResetRequest({ widgets: [] }), false);
+    },
+  },
+  {
+    label: 'the deprecated alias carrying the active dashboard cards',
+    run: () => {
+      const aliased = withLegacyWidgetsAlias(
+        normalizeDashboardConfig(
+          config({
+            active: 'work',
+            dashboards: [
+              board({}),
+              board({
+                slug: 'work',
+                name: 'Work',
+                widgets: [widget({ id: 'entities', span: 4 })],
+              }),
+            ],
+          })
+        )
+      );
+      assert.strictEqual(aliased.widgets.length, 1);
+      assert.strictEqual(aliased.widgets[0].id, 'entities');
+      assert.strictEqual(aliased.dashboards.length, 2);
+    },
+  },
+  {
+    label: 'the alias empty when nothing is stored',
+    run: () => {
+      const aliased = withLegacyWidgetsAlias(emptyDashboardConfig());
+      assert.deepStrictEqual(aliased.widgets, []);
+      assert.deepStrictEqual(aliased.dashboards, []);
+      assert.strictEqual(aliased.version, 1);
+      assert.strictEqual(aliased.active, 'default');
     },
   },
 ];
@@ -151,7 +562,7 @@ let failed = 0;
 
 for (const { label, input, expect } of accepted) {
   try {
-    const result = normalizeDashboardLayout(input);
+    const result = normalizeDashboardConfig(input);
     assert.ok(result, `${label} should be accepted`);
     expect(result);
     console.log(`  ✓ accepts ${label}`);
@@ -164,7 +575,7 @@ for (const { label, input, expect } of accepted) {
 for (const { label, input } of rejected) {
   try {
     assert.strictEqual(
-      normalizeDashboardLayout(input),
+      normalizeDashboardConfig(input),
       null,
       `${label} should be rejected`
     );
@@ -172,6 +583,16 @@ for (const { label, input } of rejected) {
   } catch (error) {
     failed += 1;
     console.error(`  ✗ rejects ${label}: ${error.message}`);
+  }
+}
+
+for (const { label, run } of compat) {
+  try {
+    run();
+    console.log(`  ✓ ${label}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`  ✗ ${label}: ${error.message}`);
   }
 }
 

--- a/tests/test-dashboard-stats-cache.js
+++ b/tests/test-dashboard-stats-cache.js
@@ -1,0 +1,360 @@
+/**
+ * Test: dashboard statistics cache
+ *
+ * /api/dashboard/stats rebuilt its whole payload per request — two uncached
+ * Paperless-ngx round trips plus a dozen SQLite queries, one of which read
+ * every openai_metrics row into memory. The dashboard polls that endpoint, and
+ * every open tab polls it separately, so the cost grew with the number of
+ * viewers while the numbers only change when a document is processed.
+ *
+ * Covers:
+ * 1. The payload keeps its shape and is built from the aggregate query
+ * 2. Concurrent readers share one build
+ * 3. A fresh cache is served without rebuilding, an expired one is not
+ * 4. invalidate() forces the next reader to rebuild
+ * 5. A failed rebuild keeps the last good payload and backs off
+ * 6. The endpoint is a thin read of the cache
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`✅  ${name}`);
+    passed++;
+  } catch (error) {
+    console.error(`❌  ${name}`);
+    console.error(`    ${error.message}`);
+    failed++;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Load the service with both collaborators replaced — no test may reach the
+// network or the database
+// ──────────────────────────────────────────────────────────────────────────────
+
+const counts = {
+  tagCount: 0,
+  correspondentCount: 0,
+  effectiveDocumentCount: 0,
+  metricsSummary: 0,
+};
+
+const fakePaperlessService = {
+  getTagCount: async () => {
+    counts.tagCount += 1;
+    return 12;
+  },
+  getCorrespondentCount: async () => {
+    counts.correspondentCount += 1;
+    return 5;
+  },
+  getEffectiveDocumentCount: async () => {
+    counts.effectiveDocumentCount += 1;
+    return 100;
+  },
+};
+
+const fakeDocumentModel = {
+  getProcessedDocumentsCount: async () => 80,
+  getOcrQueueCount: async () => 4,
+  getOcrFailedCount: async () => 1,
+  getFailedProcessingCount: async () => 3,
+  getMetricsSummary: async () => {
+    counts.metricsSummary += 1;
+    return {
+      averagePromptTokens: 10,
+      averageCompletionTokens: 4,
+      averageTotalTokens: 14,
+      tokensOverall: 1400,
+    };
+  },
+  // Reading every metrics row to average it in JavaScript is the cost this
+  // change removes; using it again should fail loudly.
+  getMetrics: async () => {
+    throw new Error('getMetrics() must not be used to build the dashboard');
+  },
+  getProcessingTimeStats: async () => [{ hour: '09', count: 2 }],
+  getTokenDistribution: async () => [{ range: '0-1k', count: 2 }],
+  getDocumentTypeStats: async () => [{ type: 'Invoice', count: 2 }],
+  getTokenTrend: async () => [
+    { day: '2026-08-13', documents: '2', totalTokens: '30' },
+  ],
+  getRecentHistoryDocuments: async () => [
+    { documentId: '7', title: '', correspondent: '', createdAt: 'now' },
+  ],
+  getLanguageDistribution: async () => [{ language: '', count: '3' }],
+  getCurrentProcessingStatus: async () => ({ processedToday: '6' }),
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === './paperlessService') return fakePaperlessService;
+  if (request === '../models/document') return fakeDocumentModel;
+  return originalLoad(request, parent, isMain);
+};
+
+const dashboardStatsService = require('../services/dashboardStatsService');
+const config = require('../config/config');
+
+Module._load = originalLoad;
+
+const originalStatsCacheTTL = config.statsCacheTTL;
+
+function reset() {
+  Object.keys(counts).forEach((key) => {
+    counts[key] = 0;
+  });
+  dashboardStatsService.reset();
+  restoreBuild();
+  config.statsCacheTTL = originalStatsCacheTTL;
+}
+
+// buildStats lives on the prototype, so deleting the own property restores it.
+function stubBuild(fn) {
+  dashboardStatsService.buildStats = fn;
+}
+
+function restoreBuild() {
+  delete dashboardStatsService.buildStats;
+}
+
+(async () => {
+  try {
+    // ──────────────────────────────────────────────────────────────────────────
+    // 1. Payload
+    // ──────────────────────────────────────────────────────────────────────────
+
+    await test('The cached payload keeps the shape the dashboard expects', async () => {
+      reset();
+      const { payload, cachedAt } = await dashboardStatsService.getStats();
+
+      assert.strictEqual(payload.success, true);
+      assert.strictEqual(counts.metricsSummary, 1, 'One aggregate query only');
+      assert.deepStrictEqual(payload.openai_data, {
+        averagePromptTokens: 10,
+        averageCompletionTokens: 4,
+        averageTotalTokens: 14,
+        tokensOverall: 1400,
+      });
+
+      const data = payload.paperless_data;
+      assert.strictEqual(data.tagCount, 12);
+      assert.strictEqual(data.correspondentCount, 5);
+      assert.strictEqual(data.documentCount, 100);
+      assert.strictEqual(data.processedDocumentCount, 80);
+      assert.strictEqual(data.ocrNeededCount, 4);
+      assert.strictEqual(data.failedCount, 4, 'OCR plus processing failures');
+      assert.strictEqual(data.queueBacklog, 8);
+      assert.strictEqual(data.processingEfficiencyRate, 95);
+      assert.strictEqual(data.failedRate, 5);
+      assert.strictEqual(data.processedToday, 6);
+
+      assert.deepStrictEqual(data.tokenTrend, [
+        { day: '2026-08-13', documents: 2, totalTokens: 30 },
+      ]);
+      assert.deepStrictEqual(data.recentActivity, [
+        {
+          documentId: 7,
+          title: 'Untitled document',
+          correspondent: 'Unknown correspondent',
+          createdAt: 'now',
+          language: 'Unknown',
+        },
+      ]);
+      assert.deepStrictEqual(data.languageDistribution, [
+        { language: 'Unknown', count: 3 },
+      ]);
+
+      assert.ok(cachedAt > 0, 'The response has to say how old the data is');
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 2. Single flight
+    // ──────────────────────────────────────────────────────────────────────────
+
+    await test('Concurrent readers share a single build', async () => {
+      reset();
+      const results = await Promise.all([
+        dashboardStatsService.getStats(),
+        dashboardStatsService.getStats(),
+        dashboardStatsService.getStats(),
+      ]);
+
+      assert.strictEqual(
+        counts.tagCount,
+        1,
+        'Three viewers must not mean three rounds of Paperless calls'
+      );
+      assert.strictEqual(counts.effectiveDocumentCount, 1);
+      results.forEach((result) =>
+        assert.strictEqual(result.payload.paperless_data.tagCount, 12)
+      );
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 3. TTL
+    // ──────────────────────────────────────────────────────────────────────────
+
+    await test('A fresh cache is served without rebuilding', async () => {
+      reset();
+      const first = await dashboardStatsService.getStats();
+      const second = await dashboardStatsService.getStats();
+
+      assert.strictEqual(counts.tagCount, 1, 'Polling must not rebuild');
+      assert.strictEqual(second.payload, first.payload, 'Same object served');
+      assert.strictEqual(second.cachedAt, first.cachedAt);
+    });
+
+    await test('An expired cache is rebuilt, and the TTL comes from config', async () => {
+      reset();
+      config.statsCacheTTL = 30;
+      assert.strictEqual(
+        dashboardStatsService.ttlMs,
+        30000,
+        'STATS_CACHE_TTL_SECONDS has to be readable at runtime'
+      );
+
+      await dashboardStatsService.getStats();
+      dashboardStatsService.cachedAt =
+        Date.now() - dashboardStatsService.ttlMs - 1;
+      await dashboardStatsService.getStats();
+
+      assert.strictEqual(counts.tagCount, 2);
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4. Invalidation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    await test('invalidate() makes the next reader rebuild', async () => {
+      reset();
+      await dashboardStatsService.getStats();
+      dashboardStatsService.invalidate();
+      await dashboardStatsService.getStats();
+
+      assert.strictEqual(
+        counts.tagCount,
+        2,
+        'A processed document has to reach the dashboard before the TTL is up'
+      );
+    });
+
+    await test('refresh() rebuilds even while the cache is fresh', async () => {
+      reset();
+      await dashboardStatsService.getStats();
+      await dashboardStatsService.refresh();
+
+      assert.strictEqual(counts.tagCount, 2);
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 5. Failure handling
+    // ──────────────────────────────────────────────────────────────────────────
+
+    await test('A failed rebuild keeps the last good payload', async () => {
+      reset();
+      const good = await dashboardStatsService.getStats();
+
+      let builds = 0;
+      stubBuild(async () => {
+        builds += 1;
+        throw new Error('Paperless-ngx unreachable');
+      });
+
+      const afterFailure = await dashboardStatsService.refresh();
+      assert.strictEqual(builds, 1);
+      assert.strictEqual(
+        afterFailure.payload,
+        good.payload,
+        'One hiccup must not blank the dashboard out'
+      );
+      assert.strictEqual(
+        afterFailure.cachedAt,
+        good.cachedAt,
+        'The timestamp keeps pointing at the data that is actually shown'
+      );
+    });
+
+    await test('A failed rebuild is not retried on every poll', async () => {
+      reset();
+      await dashboardStatsService.getStats();
+
+      let builds = 0;
+      stubBuild(async () => {
+        builds += 1;
+        throw new Error('Paperless-ngx unreachable');
+      });
+
+      dashboardStatsService.invalidate();
+      await dashboardStatsService.getStats();
+      await dashboardStatsService.getStats();
+      await dashboardStatsService.getStats();
+      assert.strictEqual(
+        builds,
+        1,
+        'A down backend must not be hit once per dashboard poll'
+      );
+
+      // Once the backoff window is over the next reader tries again.
+      dashboardStatsService.lastFailureAt =
+        Date.now() - dashboardStatsService.FAILURE_RETRY_MS - 1;
+      await dashboardStatsService.getStats();
+      assert.strictEqual(builds, 2, 'A recovered backend has to be picked up');
+    });
+
+    await test('The very first build failing surfaces to the caller', async () => {
+      reset();
+      stubBuild(async () => {
+        throw new Error('Paperless-ngx unreachable');
+      });
+
+      await assert.rejects(
+        () => dashboardStatsService.getStats(),
+        /unreachable/,
+        'With nothing cached the endpoint has to answer 500, not fake zeroes'
+      );
+    });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 6. The endpoint only reads the cache
+    // ──────────────────────────────────────────────────────────────────────────
+
+    await test('The endpoint does not assemble statistics itself', () => {
+      const routeSource = fs.readFileSync(
+        path.join(__dirname, '..', 'routes', 'setup.js'),
+        'utf8'
+      );
+      const start = routeSource.indexOf("router.get('/api/dashboard/stats'");
+      assert.ok(start > -1, 'The endpoint is missing');
+
+      const handler = routeSource.slice(
+        start,
+        routeSource.indexOf('\n});', start)
+      );
+      assert.match(handler, /dashboardStatsService\.getStats\(\)/);
+      assert.match(handler, /cachedAt/, 'The client needs the assembly time');
+      assert.ok(
+        !/documentModel\.|paperlessService\./.test(handler),
+        'Rebuilding the payload per request is what this change removes'
+      );
+    });
+  } finally {
+    reset();
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+})();

--- a/tests/test-dashboard-stats-cache.js
+++ b/tests/test-dashboard-stats-cache.js
@@ -11,7 +11,8 @@
  * 1. The payload keeps its shape and is built from the aggregate query
  * 2. Concurrent readers share one build
  * 3. A fresh cache is served without rebuilding, an expired one is not
- * 4. invalidate() forces the next reader to rebuild
+ * 4. invalidate() forces the next reader to rebuild, and survives a build that
+ *    is already running
  * 5. A failed rebuild keeps the last good payload and backs off
  * 6. The endpoint is a thin read of the cache
  */
@@ -256,6 +257,130 @@ function restoreBuild() {
       await dashboardStatsService.refresh();
 
       assert.strictEqual(counts.tagCount, 2);
+    });
+
+    // buildStats reads SQLite synchronously up front and then waits on two
+    // Paperless-ngx round trips, so a document that finishes mid-build is not
+    // in the numbers that build is about to return. These cover that window.
+
+    await test('An invalidation during a build is not buried by it', async () => {
+      reset();
+      let builds = 0;
+      const gates = [];
+      stubBuild(async () => {
+        builds += 1;
+        await new Promise((resolve) => gates.push(resolve));
+        return { success: true, build: builds };
+      });
+
+      const poll = dashboardStatsService.getStats();
+      assert.strictEqual(gates.length, 1, 'A build is under way');
+
+      // A document finishes while Paperless-ngx is still answering.
+      dashboardStatsService.invalidate();
+      gates.shift()();
+      const served = await poll;
+
+      assert.strictEqual(
+        served.payload.build,
+        1,
+        'The reader that waited still gets numbers'
+      );
+      assert.ok(
+        !dashboardStatsService.isFresh(),
+        'Numbers assembled before the change must not be stamped fresh'
+      );
+
+      const next = dashboardStatsService.getStats();
+      assert.strictEqual(gates.length, 1, 'The next reader rebuilds');
+      gates.shift()();
+      await next;
+      assert.strictEqual(builds, 2);
+    });
+
+    await test('The end-of-scan refresh does not adopt a build that predates the last document', async () => {
+      reset();
+      let processed = 5;
+      let builds = 0;
+      const gates = [];
+      stubBuild(async () => {
+        builds += 1;
+        const seen = processed;
+        await new Promise((resolve) => gates.push(resolve));
+        return {
+          success: true,
+          paperless_data: { processedDocumentCount: seen },
+        };
+      });
+
+      // A dashboard poll starts a build while the scan is still running.
+      const poll = dashboardStatsService.getStats();
+      assert.strictEqual(gates.length, 1);
+
+      // The last document lands, and the scan asks for a rebuild on its way out.
+      processed = 6;
+      dashboardStatsService.invalidate();
+      const afterScan = dashboardStatsService.refresh();
+      assert.strictEqual(
+        builds,
+        2,
+        'refresh() has to start its own build, not join the outdated one'
+      );
+
+      gates.shift()();
+      await poll;
+      gates.shift()();
+      await afterScan;
+
+      const served = await dashboardStatsService.getStats();
+      assert.strictEqual(
+        served.payload.paperless_data.processedDocumentCount,
+        6,
+        'The dashboard has to end up showing the document the scan just finished'
+      );
+      assert.strictEqual(
+        builds,
+        2,
+        'and without a third round of Paperless calls'
+      );
+    });
+
+    await test('A slow build finishing last does not overwrite newer numbers', async () => {
+      reset();
+      let processed = 5;
+      let builds = 0;
+      const gates = [];
+      stubBuild(async () => {
+        builds += 1;
+        const seen = processed;
+        await new Promise((resolve) => gates.push(resolve));
+        return {
+          success: true,
+          paperless_data: { processedDocumentCount: seen },
+        };
+      });
+
+      const stale = dashboardStatsService.getStats();
+      processed = 6;
+      dashboardStatsService.invalidate();
+      const current = dashboardStatsService.refresh();
+
+      // The newer build wins the race; the older one lands afterwards.
+      gates.pop()();
+      await current;
+      gates.pop()();
+      await stale;
+
+      assert.strictEqual(
+        dashboardStatsService.cache.paperless_data.processedDocumentCount,
+        6,
+        'The later answer must not put the older picture back'
+      );
+      assert.ok(
+        dashboardStatsService.isFresh(),
+        'and the newer numbers stay fresh, so no third build is needed'
+      );
+      assert.strictEqual(builds, 2);
     });
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -74,6 +74,32 @@
          ones ship and how wide they start. Order and span come from there so a
          new card is one partial plus one line of registry, with nothing to
          edit in this file. -->
+    <!-- The edit tray. It ships hidden and the layout module unhides it for the
+         duration of an edit session, so the page never briefly shows controls
+         for something the user did not ask for. It is server-rendered rather
+         than built in JS because it is markup, not behaviour — and because a
+         tray built from the same registry as the cards cannot fall out of step
+         with them.
+
+         The chip labels are deliberately empty here: the display title lives in
+         the card's own .zr-module__title, and the module copies it across at
+         mount. One string, one place — see config/dashboardWidgets.js. -->
+    <div class="zr-module zr-editbar hidden" id="dashboardEditbar" role="group" aria-label="Edit dashboard" tabindex="-1">
+        <div class="zr-module__body zr-row zr-row--wrap">
+            <div class="zr-row zr-row--wrap zr-grow" role="group" aria-label="Cards shown on the dashboard">
+                <% dashboardWidgets.forEach(function (widget) { %><button type="button" class="zr-btn zr-editbar__chip" data-widget-toggle="<%= widget.id %>" aria-pressed="true"><span></span></button><% }) %>
+            </div>
+            <div class="zr-row zr-editbar__actions">
+                <button type="button" class="zr-btn zr-btn--ghost" id="dashboardEditReset">
+                    <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-refresh"/></svg>
+                    <span>Reset layout</span>
+                </button>
+                <button type="button" class="zr-btn zr-btn--ghost" id="dashboardEditCancel">Cancel</button>
+                <button type="button" class="zr-btn zr-btn--primary" id="dashboardEditDone">Done</button>
+            </div>
+        </div>
+    </div>
+
     <section class="zr-grid" data-module="dashboard-layout">
         <% dashboardWidgets.forEach(function (widget) { %><%- include('partials/widgets/' + widget.id, { widget: widget }) %><% }) %>
     </section>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -67,148 +67,15 @@
 
     <!-- Every card carries a data-widget id: the layout module reorders and
          resizes them from the user's stored grid, and an id that is no longer
-         here is simply skipped. -->
+         here is simply skipped.
+
+         The cards themselves live one per file in partials/widgets/, named
+         after that id, and config/dashboardWidgets.js is the list of which
+         ones ship and how wide they start. Order and span come from there so a
+         new card is one partial plus one line of registry, with nothing to
+         edit in this file. -->
     <section class="zr-grid" data-module="dashboard-layout">
-        <!-- task runner -->
-        <article class="zr-module" data-widget="task-runner" data-span="12">
-            <div class="zr-module__head">
-                <span class="zr-dot zr-dot--ok" id="runnerDot"></span>
-                <h2 class="zr-module__title">Task runner</h2>
-                <div class="zr-module__actions">
-                    <span class="zr-sm zr-faint zr-freshness" id="statusLastUpdated"></span>
-                    <button class="zr-btn zr-btn--primary" type="button" id="scanButton">
-                        <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-play"/></svg>
-                        <span>Scan now</span>
-                    </button>
-                    <button class="zr-btn zr-btn--danger hidden" type="button" id="stopScanButton" aria-label="Stop scan">
-                        <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-stop"/></svg>
-                        <span>Stop</span>
-                    </button>
-                </div>
-            </div>
-            <div class="zr-module__body zr-col">
-                <div class="zr-row">
-                    <div class="zr-grow zr-col zr-col--tight">
-                        <strong id="runnerLabel">System idle</strong>
-                        <span class="zr-sm zr-faint zr-truncate" id="runnerDetail">Waiting for new documents</span>
-                    </div>
-                    <span class="zr-badge zr-badge--info hidden" id="currentDocId"></span>
-                    <%- include('partials/runner-seal') %>
-                </div>
-
-                <div class="zr-row zr-row--wrap zr-sm zr-muted" style="gap: var(--zr-4)">
-                    <span><strong class="zr-num" id="processedToday">0</strong> processed today</span>
-                    <span>last document <strong id="lastProcessed">no data</strong></span>
-                </div>
-            </div>
-
-            <div class="zr-module__foot">
-                <div class="zr-row zr-row--between">
-                    <span>Recent activity</span>
-                    <a class="zr-row" href="/history" style="gap: 4px">
-                        History
-                        <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-chevron-right"/></svg>
-                    </a>
-                </div>
-            </div>
-            <div class="zr-list" id="recentActivityList"></div>
-        </article>
-        <!-- document types -->
-        <article class="zr-module" data-widget="document-types" data-span="4">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Document types</h2>
-            </div>
-            <div class="zr-module__body zr-row zr-module__body--chart">
-                <svg class="zr-donut" id="documentTypesDonut" aria-hidden="true"></svg>
-                <div class="zr-grow zr-col zr-col--tight zr-sm" id="documentTypesLegend"></div>
-            </div>
-        </article>
-        <!-- entities and rates -->
-        <article class="zr-module" data-widget="entities" data-span="4">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Entities</h2>
-            </div>
-            <div class="zr-module__body zr-col">
-                <button class="zr-row zr-entitybtn" type="button" id="showTagDetails">
-                    <span class="zr-badge zr-badge--brand">
-                        <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-tag"/></svg>
-                    </span>
-                    <span class="zr-grow"><strong id="totalTags">&mdash;</strong> tags</span>
-                    <svg class="zr-icon zr-faint" aria-hidden="true"><use href="/icons.svg#i-chevron-right"/></svg>
-                </button>
-                <button class="zr-row zr-entitybtn" type="button" id="showCorrespondentDetails">
-                    <span class="zr-badge zr-badge--brand">
-                        <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-building"/></svg>
-                    </span>
-                    <span class="zr-grow"><strong id="totalCorrespondents">&mdash;</strong> correspondents</span>
-                    <svg class="zr-icon zr-faint" aria-hidden="true"><use href="/icons.svg#i-chevron-right"/></svg>
-                </button>
-
-                <div class="zr-col zr-col--tight zr-sm" style="margin-top: var(--zr-2)">
-                    <div class="zr-kv">
-                        <span class="zr-kv__k">Efficiency</span>
-                        <span class="zr-kv__v" id="efficiencyRate">&mdash;</span>
-                    </div>
-                    <div class="zr-kv">
-                        <span class="zr-kv__k">Queue backlog</span>
-                        <span class="zr-kv__v" id="queueBacklog">&mdash;</span>
-                    </div>
-                    <div class="zr-kv">
-                        <span class="zr-kv__k">Failed share</span>
-                        <span class="zr-kv__v" id="failedRate">&mdash;</span>
-                    </div>
-                </div>
-            </div>
-        </article>
-        <!-- token usage -->
-        <article class="zr-module" data-widget="token-usage" data-span="4">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Token usage</h2>
-                <span class="zr-module__meta">last 7 days</span>
-            </div>
-            <div class="zr-module__body zr-col">
-                <div class="zr-row zr-row--between">
-                    <span class="zr-stat__value" id="tokensOverall">&mdash;</span>
-                    <span class="zr-sm zr-faint">total</span>
-                </div>
-                <svg class="zr-spark" id="tokenTrendSpark" aria-hidden="true"></svg>
-                <p class="zr-sm zr-faint hidden" id="tokenTrendEmpty">No token trend yet.</p>
-                <div class="zr-col zr-col--tight zr-sm">
-                    <div class="zr-kv"><span class="zr-kv__k">Prompt, average</span><span class="zr-kv__v" id="avgPromptTokens">&mdash;</span></div>
-                    <div class="zr-kv"><span class="zr-kv__k">Completion, average</span><span class="zr-kv__v" id="avgCompletionTokens">&mdash;</span></div>
-                    <div class="zr-kv"><span class="zr-kv__k">Total per document</span><span class="zr-kv__v" id="avgTotalTokens">&mdash;</span></div>
-                </div>
-            </div>
-        </article>
-        <!-- token distribution -->
-        <article class="zr-module" data-widget="token-distribution" data-span="4">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Token distribution</h2>
-                <span class="zr-module__meta">documents per range</span>
-            </div>
-            <div class="zr-module__body">
-                <div class="zr-barlist" id="tokenDistributionList"></div>
-            </div>
-        </article>
-        <!-- language mix -->
-        <article class="zr-module" data-widget="language-mix" data-span="4">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Language mix</h2>
-            </div>
-            <div class="zr-module__body">
-                <div class="zr-barlist" id="languageDistributionList"></div>
-            </div>
-        </article>
-        <!-- processing split -->
-        <article class="zr-module" data-widget="processing-status" data-span="4">
-            <div class="zr-module__head">
-                <h2 class="zr-module__title">Processing status</h2>
-            </div>
-            <div class="zr-module__body zr-row zr-module__body--chart">
-                <svg class="zr-donut" id="processingDonut" aria-hidden="true"></svg>
-                <div class="zr-grow zr-col zr-col--tight zr-sm" id="processingLegend"></div>
-            </div>
-        </article>
+        <% dashboardWidgets.forEach(function (widget) { %><%- include('partials/widgets/' + widget.id, { widget: widget }) %><% }) %>
     </section>
 
     <dialog class="zr-dialog" id="detailsModal" aria-labelledby="detailsModalTitle">

--- a/views/manual.ejs
+++ b/views/manual.ejs
@@ -17,14 +17,20 @@
                 <div class="zr-module">
                     <h2 class="zr-module__title">Select Document</h2>
                     <div class="manual-search-wrapper">
-                        <input
-                            id="manualDocumentSearchInput"
-                            class="zr-input"
-                            type="search"
-                            placeholder="Search documents (title, ID, correspondent)..."
-                            autocomplete="off">
-                        <div id="manualDocumentSearchResults" class="manual-search-results hidden" role="listbox" aria-label="Manual document search results"></div>
-                        <input type="hidden" id="documentSelect" value="">
+                        <!-- Field and results share one box: the results panel
+                             is positioned against it and drops over the page,
+                             instead of pushing the rest of the form down on
+                             every keystroke. -->
+                        <div class="manual-search-anchor">
+                            <input
+                                id="manualDocumentSearchInput"
+                                class="zr-input"
+                                type="search"
+                                placeholder="Search documents (title, ID, correspondent)..."
+                                autocomplete="off">
+                            <div id="manualDocumentSearchResults" class="manual-search-results hidden" role="listbox" aria-label="Manual document search results"></div>
+                            <input type="hidden" id="documentSelect" value="">
+                        </div>
                         <p id="manualDocumentSearchStatus" class="manual-search-status">Loading recent documents...</p>
                     </div>
                 </div>

--- a/views/ocr.ejs
+++ b/views/ocr.ejs
@@ -59,14 +59,20 @@ MISTRAL_OCR_MODEL=mistral-ocr-latest</pre>
                                 <option value="tags">Tags</option>
                                 <option value="correspondent">Correspondent</option>
                             </select>
-                            <input
-                                id="manualDocSearchInput"
-                                class="zr-input"
-                                type="search"
-                                placeholder="Search documents to add..."
-                                autocomplete="off">
-                            <div id="manualDocSearchResults" class="manual-search-results hidden" role="listbox" aria-label="OCR document search results"></div>
-                            <input type="hidden" id="manualDocId" value="">
+                            <!-- Field and results share one box: the results
+                                 panel is positioned against it and drops over
+                                 the page, instead of taking a third slot on
+                                 the toolbar row next to the field. -->
+                            <div class="manual-search-anchor">
+                                <input
+                                    id="manualDocSearchInput"
+                                    class="zr-input"
+                                    type="search"
+                                    placeholder="Search documents to add..."
+                                    autocomplete="off">
+                                <div id="manualDocSearchResults" class="manual-search-results hidden" role="listbox" aria-label="OCR document search results"></div>
+                                <input type="hidden" id="manualDocId" value="">
+                            </div>
                         </div>
 
                         <select id="statusFilter" class="zr-select app-toolbar-scope">
@@ -92,7 +98,6 @@ MISTRAL_OCR_MODEL=mistral-ocr-latest</pre>
                     </div>
                     <!-- Live search feedback only; empty while idle. -->
                     <p id="manualDocSearchStatus" class="manual-search-status zr-xs"></p>
-                    </div>
                 </div>
 
                 <!-- Queue Table -->
@@ -134,7 +139,6 @@ MISTRAL_OCR_MODEL=mistral-ocr-latest</pre>
                 <% } %>
 
             </div>
-    </div>
 
     <!-- Progress Overlay (SSE) -->
     <div id="progressOverlay" style="display:none;">

--- a/views/partials/widgets/document-types.ejs
+++ b/views/partials/widgets/document-types.ejs
@@ -1,0 +1,9 @@
+<article class="zr-module" data-widget="document-types" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <h2 class="zr-module__title">Document types</h2>
+    </div>
+    <div class="zr-module__body zr-row zr-module__body--chart">
+        <svg class="zr-donut" id="documentTypesDonut" aria-hidden="true"></svg>
+        <div class="zr-grow zr-col zr-col--tight zr-sm" id="documentTypesLegend"></div>
+    </div>
+</article>

--- a/views/partials/widgets/entities.ejs
+++ b/views/partials/widgets/entities.ejs
@@ -1,0 +1,36 @@
+<article class="zr-module" data-widget="entities" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <h2 class="zr-module__title">Entities</h2>
+    </div>
+    <div class="zr-module__body zr-col">
+        <button class="zr-row zr-entitybtn" type="button" id="showTagDetails">
+            <span class="zr-badge zr-badge--brand">
+                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-tag"/></svg>
+            </span>
+            <span class="zr-grow"><strong id="totalTags">&mdash;</strong> tags</span>
+            <svg class="zr-icon zr-faint" aria-hidden="true"><use href="/icons.svg#i-chevron-right"/></svg>
+        </button>
+        <button class="zr-row zr-entitybtn" type="button" id="showCorrespondentDetails">
+            <span class="zr-badge zr-badge--brand">
+                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-building"/></svg>
+            </span>
+            <span class="zr-grow"><strong id="totalCorrespondents">&mdash;</strong> correspondents</span>
+            <svg class="zr-icon zr-faint" aria-hidden="true"><use href="/icons.svg#i-chevron-right"/></svg>
+        </button>
+
+        <div class="zr-col zr-col--tight zr-sm" style="margin-top: var(--zr-2)">
+            <div class="zr-kv">
+                <span class="zr-kv__k">Efficiency</span>
+                <span class="zr-kv__v" id="efficiencyRate">&mdash;</span>
+            </div>
+            <div class="zr-kv">
+                <span class="zr-kv__k">Queue backlog</span>
+                <span class="zr-kv__v" id="queueBacklog">&mdash;</span>
+            </div>
+            <div class="zr-kv">
+                <span class="zr-kv__k">Failed share</span>
+                <span class="zr-kv__v" id="failedRate">&mdash;</span>
+            </div>
+        </div>
+    </div>
+</article>

--- a/views/partials/widgets/language-mix.ejs
+++ b/views/partials/widgets/language-mix.ejs
@@ -1,0 +1,8 @@
+<article class="zr-module" data-widget="language-mix" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <h2 class="zr-module__title">Language mix</h2>
+    </div>
+    <div class="zr-module__body">
+        <div class="zr-barlist" id="languageDistributionList"></div>
+    </div>
+</article>

--- a/views/partials/widgets/processing-status.ejs
+++ b/views/partials/widgets/processing-status.ejs
@@ -1,0 +1,9 @@
+<article class="zr-module" data-widget="processing-status" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <h2 class="zr-module__title">Processing status</h2>
+    </div>
+    <div class="zr-module__body zr-row zr-module__body--chart">
+        <svg class="zr-donut" id="processingDonut" aria-hidden="true"></svg>
+        <div class="zr-grow zr-col zr-col--tight zr-sm" id="processingLegend"></div>
+    </div>
+</article>

--- a/views/partials/widgets/task-runner.ejs
+++ b/views/partials/widgets/task-runner.ejs
@@ -1,0 +1,43 @@
+<article class="zr-module" data-widget="task-runner" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <span class="zr-dot zr-dot--ok" id="runnerDot"></span>
+        <h2 class="zr-module__title">Task runner</h2>
+        <div class="zr-module__actions">
+            <span class="zr-sm zr-faint zr-freshness" id="statusLastUpdated"></span>
+            <button class="zr-btn zr-btn--primary" type="button" id="scanButton">
+                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-play"/></svg>
+                <span>Scan now</span>
+            </button>
+            <button class="zr-btn zr-btn--danger hidden" type="button" id="stopScanButton" aria-label="Stop scan">
+                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-stop"/></svg>
+                <span>Stop</span>
+            </button>
+        </div>
+    </div>
+    <div class="zr-module__body zr-col">
+        <div class="zr-row">
+            <div class="zr-grow zr-col zr-col--tight">
+                <strong id="runnerLabel">System idle</strong>
+                <span class="zr-sm zr-faint zr-truncate" id="runnerDetail">Waiting for new documents</span>
+            </div>
+            <span class="zr-badge zr-badge--info hidden" id="currentDocId"></span>
+            <%- include('../runner-seal') %>
+        </div>
+
+        <div class="zr-row zr-row--wrap zr-sm zr-muted" style="gap: var(--zr-4)">
+            <span><strong class="zr-num" id="processedToday">0</strong> processed today</span>
+            <span>last document <strong id="lastProcessed">no data</strong></span>
+        </div>
+    </div>
+
+    <div class="zr-module__foot">
+        <div class="zr-row zr-row--between">
+            <span>Recent activity</span>
+            <a class="zr-row" href="/history" style="gap: 4px">
+                History
+                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-chevron-right"/></svg>
+            </a>
+        </div>
+    </div>
+    <div class="zr-list" id="recentActivityList"></div>
+</article>

--- a/views/partials/widgets/token-distribution.ejs
+++ b/views/partials/widgets/token-distribution.ejs
@@ -1,0 +1,9 @@
+<article class="zr-module" data-widget="token-distribution" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <h2 class="zr-module__title">Token distribution</h2>
+        <span class="zr-module__meta">documents per range</span>
+    </div>
+    <div class="zr-module__body">
+        <div class="zr-barlist" id="tokenDistributionList"></div>
+    </div>
+</article>

--- a/views/partials/widgets/token-usage.ejs
+++ b/views/partials/widgets/token-usage.ejs
@@ -1,0 +1,19 @@
+<article class="zr-module" data-widget="token-usage" data-span="<%= widget.span %>">
+    <div class="zr-module__head">
+        <h2 class="zr-module__title">Token usage</h2>
+        <span class="zr-module__meta">last 7 days</span>
+    </div>
+    <div class="zr-module__body zr-col">
+        <div class="zr-row zr-row--between">
+            <span class="zr-stat__value" id="tokensOverall">&mdash;</span>
+            <span class="zr-sm zr-faint">total</span>
+        </div>
+        <svg class="zr-spark" id="tokenTrendSpark" aria-hidden="true"></svg>
+        <p class="zr-sm zr-faint hidden" id="tokenTrendEmpty">No token trend yet.</p>
+        <div class="zr-col zr-col--tight zr-sm">
+            <div class="zr-kv"><span class="zr-kv__k">Prompt, average</span><span class="zr-kv__v" id="avgPromptTokens">&mdash;</span></div>
+            <div class="zr-kv"><span class="zr-kv__k">Completion, average</span><span class="zr-kv__v" id="avgCompletionTokens">&mdash;</span></div>
+            <div class="zr-kv"><span class="zr-kv__k">Total per document</span><span class="zr-kv__v" id="avgTotalTokens">&mdash;</span></div>
+        </div>
+    </div>
+</article>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -100,7 +100,7 @@
                                     <label class="zr-field__name">Detected Public URL</label>
                                     <!-- Same one-row value + button shape as the secret fields. -->
                                     <div class="zr-inputgroup">
-                                        <div id="paperlessDetectedUrlValue" class="zr-input zr-grow" style="height:auto; word-break:break-all">Loading…</div>
+                                        <div id="paperlessDetectedUrlValue" class="zr-input zr-input--static zr-grow">Loading…</div>
                                         <button type="button" id="refreshPublicUrlDetection" class="zr-btn">
                                             <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-refresh"/></svg>Refresh
                                         </button>

--- a/views/styleguide.ejs
+++ b/views/styleguide.ejs
@@ -360,9 +360,20 @@
                         <p class="zr-field__hint">Set through the environment, so the form cannot change it.</p>
                     </div>
                     <div class="zr-field zr-field--stacked">
+                        <span class="zr-field__name">Reported value — .zr-input--static</span>
+                        <div class="zr-inputgroup">
+                            <div class="zr-input zr-input--static zr-grow">https://paperless.example.com/api/documents/</div>
+                            <button type="button" class="zr-btn">
+                                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-refresh"/></svg>
+                                Refresh
+                            </button>
+                        </div>
+                        <p class="zr-field__hint">Nobody types this one — the page reports it. It keeps the field box so it lines up with the button, and grows instead of clipping.</p>
+                    </div>
+                    <div class="zr-field zr-field--stacked">
                         <span class="zr-field__name">Masked key — .zr-apikey</span>
-                        <div class="zr-input zr-mono zr-apikey" tabindex="0">zr_4f1c9b0e7a2d5843bc61</div>
-                        <p class="zr-field__hint">Blurred until hovered or focused.</p>
+                        <div class="zr-input zr-mono zr-apikey" tabindex="0">zr_4f1c9b0e7a2d5843bc6188e07a2d5843bc6199f31c9b0e7a2d5843bc6104e7a2d5843bc6199f31c9b0e</div>
+                        <p class="zr-field__hint">Blurred until hovered or focused. One line: a key too long for the box ends in an ellipsis rather than outside it.</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
Nine pieces of usage feedback on the dashboard, queues and settings, verified first and then fixed — three areas. A five-lens review of the result then found five more defects, fixed in four further commits (see **Review round** at the end). Eleven commits total.

## Dashboard (feedback 1–3)

**The slowness was real and had three causes** (`1b880ee`): every stats request made two uncached Paperless-ngx round trips, the effective-count path's worst case walks the whole library at 100ms per page (blowing through the client's 15s timeout), and `SELECT * FROM openai_metrics` materialized every row so the route could reduce over it four times. The payload is now assembled in a `dashboardStatsService` (single-flight, stale-on-error, `reset()` test seam), warmed at startup, refreshed by a per-minute cron, invalidated after each processed document and rebuilt when a scan run ends. The route is a thin cached read returning `cachedAt`, which the freshness label now shows. The metrics table is aggregated in SQL with COALESCE semantics matching the old reduces bit-for-bit. Ten new offline test cases; the fake model's `getMetrics()` throws, so regressing to the row-materializing query fails the suite.

**"Reset layout" is gone; the dashboard is view-only until you ask** (`9141f83`): "Edit dashboard" opens a session — grips, drag and the widget tray exist only inside it. Nothing writes during a session: Done sends one PUT, Cancel restores the snapshot, walking away leaves no trace. Widgets toggle per chip; a hidden card is invisible while reading but faded-and-draggable inside the session, keeps its DOM node so its charts stay live, and keeps its place and size for when it returns. Reset-then-Done stores a true reset (`dashboards:[]`), so future default changes still reach the user.

**Widgets are a library now** (`a17f7e6`): each card is one EJS partial under `views/partials/widgets/`, listed in `config/dashboardWidgets.js` — a new widget is one partial plus one registry line. Storage became v1: a list of named dashboards (slug, name, widgets with an explicit `hidden` flag), so a dashboard switcher can come later **without a migration**. A widget unknown to a stored layout — e.g. shipped by an update — surfaces visibly instead of staying hidden forever. The partial split renders byte-identical HTML, verified mechanically.

## Queues and History (feedback 4–5)

**OCR search** (`f32ab13`): the results were an in-flow flex item *inside* the toolbar row — that was the whole bug. They are now a real dropdown pinned under the input (shadow, 320px scroll, hover and keyboard highlight — the keyboard state was verified to be an `.active` class; `aria-selected` is written once and never updated). One rule the plan missed: `.zr-module` clips and is its own stacking context via `container-type`, so the hosting module opts out through `:has()`. Also repaired: two stray closing divs that pushed the queue table out of the page wrapper. `manual.ejs` adopts the same overlay.

**History row menu** (`d06f2f1`) gains Reanalyze and Ignore (both endpoints existed; the menu never offered them), plus a latent-bug fix: restore/rescan called `this.table?.ajax.reload()` on a wrapper that only has `reload()` — a successful action showed its success toast, then threw and reported failure right after. The ignore title travels through a quote-safe escape; the previous helper left `"` intact and a Paperless title is free text.

## Settings (feedback 6–9)

One commit (`d26b764`): anchors get `scroll-margin-top` so all seven tabs land flush below the sticky topbar (no scroll offset existed anywhere); the detected public URL wears a new `.zr-input--static` variant (the box of an input, the manner of a report) instead of the file's only inline styles; the API key ellipses instead of painting through its border — proven that `text-overflow` cannot reach an anonymous flex item, so the box became block with line-height centring (copy and tooltip read the dataset, lossless); and the sixty-odd fields read like table rows now — full-bleed hairlines plus a hover band, with the switch tiles, alerts and the changelog tab excluded for reasons the stylesheet documents inline. Zebra striping was considered and rejected: the framework's tables don't stripe, and stripes double-box the switch tiles.

## Review notes

- **Format v1 is a breaking change to an unreleased API** — no migration, documented in @swagger, OpenAPI regenerated (idempotent; CI drift check passes per commit).
- The layout validator is strict where code writes (`version !== 1` rejects) and forgiving where users type (stale `active` falls back instead of 400).
- Edit-mode semantics were driven in a real browser against a PUT-counting stub: zero writes across chip/keyboard/pointer/drag interactions, exactly one on Done, Cancel restores, reload re-applies, failed PUT keeps the session open with a retry that works.
- Suite: 62 passed / 6 skipped (server-dependent) / 0 failed; eslint, stylelint, prettier clean on every touched file.
- Crossing 861px mid-session was re-checked in a browser that emits real `resize`/`matchMedia` events: the session ends the way Cancel does, with no PUT. The media rule that hides bar, tray and grips below 861px holds independently of the event.

## Review round

Five independent reviewers went over the diff above; five defects survived adversarial verification and are fixed here. Two of the five have root causes older than this branch, but this branch is what made them reachable.

**The statistics cache could serve numbers from before a change and call them fresh** (`e1a2ecb`). `buildStats()` reads SQLite up front and then waits on two HTTP round trips; `invalidate()` only zeroed `cachedAt`, which the resolving build overwrote — so a document finishing mid-build was dropped from the record. The end-of-scan `refresh()` could not repair it, because the in-flight check ran before the force flag and adopted the build already known to be outdated. The cache now carries a generation: an invalidation bumps it, each build remembers the one it started in, and freshness compares the two. A superseded build is still stored and served — dropping it would leave a fast scan rebuilding on every poll with nothing cached — but never reads as fresh, and a slow one finishing last no longer puts the older picture back. The same commit closes the invalidation gap: `invalidate()` had exactly one caller, so manual processing, the manual queue, the OCR drains and the scan's own failure branch left the counters stale — and since the client only refetches when `lastProcessed` changes, the wrong figure stayed on screen indefinitely.

**The freshness label ignored the `cachedAt` this PR had just plumbed through** (`f506c39`). One shared timestamp, restamped to "now" by the three-second status poll, meant a stale-served payload still looked seconds old — precisely the hazard the module's header warns about. Timestamps are now per source and the label reports the oldest.

**The history row menu never opened on a phone** (`f6b81ba`, pre-existing). `data-table.js` renders each row twice — table and card — from the same string, so the popover id existed twice; below 860px both `popovertarget` and `getElementById` resolved to the copy inside the hidden table, whose zero-size box made `row-menu.js` dismiss the popover immediately. The renderer now receives its rendering surface and puts it in the id. This branch is what put Reanalyze and Ignore in that menu, so all five actions were unreachable on mobile.

**Resizing between 861 and 1180px stored a width nobody saw** (`1cfdd5e`, pre-existing). `modules.css` remaps spans in that band (3–4 render half, 5 and 7–11 render full) and the snapping worked from raw twelfths, so a card jumped half → full → half under a rightward drag and Done stored something else again. Snapping now offers only the widths the current viewport renders. Raising the edit gate to 1181px was the alternative and would have cost tablet windows the feature outright.

Three new offline cases cover the cache race and fail against the previous service; the four UI fixes were each verified in a browser, before and after. Suite unchanged at 62 passed / 6 skipped / 0 failed, lint and OpenAPI drift clean.

Two findings were left out by decision: `currentLayout()` always writes a single board slugged `default`, so a config with several boards loses the others on Done, and the reset branch runs before the validator, so `{"dashboards":[]}` clears the row without a version check. Neither is reachable from the shipped UI — both want fixing before a dashboard switcher exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

