### PR TITLE
Let the instance choose how a date reads

### DIFF
--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -3794,6 +3794,15 @@
                     "type": "string",
                     "description": "Run AI analysis directly after automatic OCR (yes/no)",
                     "example": "yes"
+                  },
+                  "dateFormat": {
+                    "type": "string",
+                    "description": "How every date in the web interface is rendered",
+                    "enum": [
+                      "DD.MM.YYYY",
+                      "YYYY-MM-DD"
+                    ],
+                    "example": "DD.MM.YYYY"
                   }
                 }
               }

--- a/config/config.js
+++ b/config/config.js
@@ -30,6 +30,25 @@ const LOG_LEVEL_WEIGHTS = {
 };
 const VALID_LOG_LEVELS = Object.keys(LOG_LEVEL_WEIGHTS);
 
+/* The date formats the interface offers. A locale's own idea of the order is
+   deliberately not among them: the dates sit in dense table cells without a
+   label, and an unadorned 08/09 has to mean one thing whoever is reading. Both
+   formats pad the month and day to two digits for the same reason — a column of
+   15.08.2026 and 3.9.2026 does not scan. */
+const VALID_DATE_FORMATS = ['DD.MM.YYYY', 'YYYY-MM-DD'];
+const DEFAULT_DATE_FORMAT = 'DD.MM.YYYY';
+
+const normalizeDateFormat = (value) => {
+  if (!value) {
+    return DEFAULT_DATE_FORMAT;
+  }
+
+  const normalized = String(value).trim().toUpperCase();
+  return VALID_DATE_FORMATS.includes(normalized)
+    ? normalized
+    : DEFAULT_DATE_FORMAT;
+};
+
 const normalizeLogLevel = (value) => {
   if (!value) {
     return 'info';
@@ -205,6 +224,24 @@ if (
   );
 }
 process.env.LOG_LEVEL = logLevel;
+
+/* Written back onto the environment so the settings view and the .env export,
+   which both read process.env directly, show the value the app actually renders
+   with rather than the typo an operator left behind. */
+const requestedDateFormat = process.env.DATE_FORMAT;
+const dateFormat = normalizeDateFormat(requestedDateFormat);
+if (
+  requestedDateFormat &&
+  String(requestedDateFormat).trim().toUpperCase() !== dateFormat
+) {
+  startupLog(
+    logLevel,
+    'warn',
+    `[WARN] Invalid DATE_FORMAT "${requestedDateFormat}". Falling back to "${dateFormat}".`
+  );
+}
+process.env.DATE_FORMAT = dateFormat;
+
 if (CONFIG_SOURCE_MODE === LEGACY_CONFIG_SOURCE_MODE) {
   startupLog(logLevel, 'debug', 'Loading legacy .env from:', envPath);
 } else {
@@ -373,6 +410,11 @@ module.exports = {
     return getCookieSecureMode();
   },
   logLevel,
+  // How every date in the interface is rendered. The browser gets it through a
+  // <meta> tag in the shell, so one setting covers server-rendered pages and
+  // the tables the page scripts build alike.
+  dateFormat,
+  validDateFormats: VALID_DATE_FORMATS,
   disableAutomaticProcessing: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
   exposeApiDocs: parseEnvBoolean(process.env.EXPOSE_API_DOCS, 'no'),
   // Contacts api.github.com once a day to compare release tags. Set to `no` in

--- a/public/css/tables.css
+++ b/public/css/tables.css
@@ -47,6 +47,13 @@
     flex-wrap: nowrap;
     justify-content: flex-end;
   }
+  /* A date column never breaks its dates. YYYY-MM-DD offers the browser two
+     break opportunities at its hyphens and it takes them the moment the column
+     is tight, so the same row that reads 03.09.2026 on one line came back as
+     2026- / 09-03 on two the moment the format was switched. */
+  .zr-table__date {
+    white-space: nowrap;
+  }
   .zr-table tbody tr:hover {
     background: var(--zr-surface-2);
   }

--- a/public/js/date-format.js
+++ b/public/js/date-format.js
@@ -1,0 +1,90 @@
+/**
+ * Renders dates the way the instance is configured to render them.
+ *
+ * A classic script loaded synchronously in <head>, because the page scripts
+ * that build most of the tables — history, ocr, failed, ignored — cannot import
+ * an ES module. Module land reaches this same implementation through
+ * modules/date-format.js rather than a second copy.
+ *
+ * The configured format arrives in the <meta name="date-format"> tag the shell
+ * writes. Anything unknown there falls back to DD.MM.YYYY, which is what
+ * config/config.js has already normalized the value to on the server; the
+ * fallback exists for pages rendered outside the shell, not as a second opinion.
+ */
+(function () {
+  'use strict';
+
+  const FALLBACK_FORMAT = 'DD.MM.YYYY';
+  const FORMATS = {
+    'DD.MM.YYYY': (parts) => `${parts.day}.${parts.month}.${parts.year}`,
+    'YYYY-MM-DD': (parts) => `${parts.year}-${parts.month}-${parts.day}`,
+  };
+
+  function activeFormat() {
+    const requested = String(
+      document
+        .querySelector('meta[name="date-format"]')
+        ?.getAttribute('content') || ''
+    )
+      .trim()
+      .toUpperCase();
+
+    return FORMATS[requested] ? requested : FALLBACK_FORMAT;
+  }
+
+  /**
+   * Accepts what the endpoints actually hand out: ISO strings, SQLite's
+   * "YYYY-MM-DD HH:MM:SS" (which Safari refuses over the space), Date objects
+   * and epoch milliseconds. Returns null for everything that is not a real
+   * date, so each caller decides for itself what an empty cell should read.
+   */
+  function parseValue(value) {
+    if (value === null || value === undefined || value === '') return null;
+
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    const parsed =
+      typeof value === 'number'
+        ? new Date(value)
+        : new Date(String(value).replace(' ', 'T'));
+
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function partsOf(date) {
+    return {
+      year: String(date.getFullYear()),
+      month: pad(date.getMonth() + 1),
+      day: pad(date.getDate()),
+    };
+  }
+
+  function format(value, options) {
+    const parsed = parseValue(value);
+    if (!parsed) return (options && options.fallback) || '';
+    return FORMATS[activeFormat()](partsOf(parsed));
+  }
+
+  function formatDateTime(value, options) {
+    const parsed = parseValue(value);
+    if (!parsed) return (options && options.fallback) || '';
+
+    // A 24-hour clock under both formats: the setting is about the order of the
+    // date parts, and an am/pm time belongs to neither of the two on offer.
+    const time = [
+      pad(parsed.getHours()),
+      pad(parsed.getMinutes()),
+      pad(parsed.getSeconds()),
+    ].join(':');
+
+    return `${FORMATS[activeFormat()](partsOf(parsed))} ${time}`;
+  }
+
+  window.zrDate = { format, formatDateTime, activeFormat };
+})();

--- a/public/js/document-omnibox.js
+++ b/public/js/document-omnibox.js
@@ -8,19 +8,14 @@
   }
 
   function defaultFormatDate(createdValue) {
-    if (!createdValue) {
-      return 'Unknown date';
-    }
-
-    const parsedDate = new Date(createdValue);
-    if (Number.isNaN(parsedDate.getTime())) {
-      return String(createdValue).slice(0, 10) || 'Unknown date';
-    }
-
-    const year = parsedDate.getFullYear();
-    const month = String(parsedDate.getMonth() + 1).padStart(2, '0');
-    const day = String(parsedDate.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
+    // A value the formatter cannot parse keeps its leading YYYY-MM-DD rather
+    // than disappearing behind a placeholder — the pill is there to tell two
+    // search hits apart, and half a date still does that.
+    return (
+      window.zrDate.format(createdValue) ||
+      String(createdValue || '').slice(0, 10) ||
+      'Unknown date'
+    );
   }
 
   const DOCUMENT_OMNIBOX_PRESETS = {

--- a/public/js/failed.js
+++ b/public/js/failed.js
@@ -84,11 +84,12 @@
         const reasonLabel = formatFailedReason(item.failed_reason);
         const sourceLabel = formatFailedSource(item.source);
         // Date only; the full timestamp stays reachable through the cell title.
-        const updatedAt = item.updated_at ? new Date(item.updated_at) : null;
-        const updated = updatedAt ? updatedAt.toLocaleDateString() : '–';
-        const updatedTitle = updatedAt
-          ? escHtml(updatedAt.toLocaleString())
-          : '';
+        const updated = window.zrDate.format(item.updated_at, {
+          fallback: '–',
+        });
+        const updatedTitle = escHtml(
+          window.zrDate.formatDateTime(item.updated_at)
+        );
 
         // data-label carries the column name into the stacked phone layout,
         // where the header row is hidden.
@@ -97,7 +98,7 @@
                 <td data-label="Title" class="zr-truncate" title="${escHtml(item.title || '')}">${escHtml(item.title || '–')}</td>
                 <td data-label="Reason"><span class="zr-badge">${reasonLabel}</span></td>
                 <td data-label="Source" class="zr-sm">${sourceLabel}</td>
-                <td data-label="Updated" class="zr-sm zr-faint" title="${updatedTitle}">${updated}</td>
+                <td data-label="Updated" class="zr-sm zr-faint zr-table__date" title="${updatedTitle}">${updated}</td>
                 <td data-label="" class="zr-table__actions"><div class="zr-row">
                     <button class="zr-btn failed-reset-btn" data-id="${item.document_id}" title="Reset failed state and allow re-scan">
                         <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-undo"/></svg> Reset

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -245,7 +245,7 @@ class HistoryManager {
           render: (value, row) =>
             `<div class="zr-strong">${escape(value)}</div>` +
             // Date only, like the queue pages; the full timestamp sits in the title.
-            `<div class="zr-sm zr-faint" title="${escape(new Date(row.created_at).toLocaleString())}">Modified: ${escape(new Date(row.created_at).toLocaleDateString())}</div>`,
+            `<div class="zr-sm zr-faint" title="${escape(window.zrDate.formatDateTime(row.created_at))}">Modified: ${escape(window.zrDate.format(row.created_at, { fallback: '–' }))}</div>`,
         },
         {
           key: 'correspondent',
@@ -907,10 +907,10 @@ class HistoryManager {
       }
 
       // --- Processed At ---
-      document.getElementById('infoModalProcessedAt').textContent = data.history
-        .created_at
-        ? new Date(data.history.created_at).toLocaleString()
-        : 'Unknown';
+      document.getElementById('infoModalProcessedAt').textContent =
+        window.zrDate.formatDateTime(data.history.created_at, {
+          fallback: 'Unknown',
+        });
 
       // --- Token Usage ---
       const tokensSection = document.getElementById('infoModalTokensSection');

--- a/public/js/ignored.js
+++ b/public/js/ignored.js
@@ -95,9 +95,10 @@
           : `<span class="zr-mono">#${item.document_id}</span>`;
 
         // Date only; the full timestamp stays reachable through the cell title.
-        const addedAt = item.created_at ? new Date(item.created_at) : null;
-        const added = addedAt ? addedAt.toLocaleDateString() : '–';
-        const addedTitle = addedAt ? escHtml(addedAt.toLocaleString()) : '';
+        const added = window.zrDate.format(item.created_at, { fallback: '–' });
+        const addedTitle = escHtml(
+          window.zrDate.formatDateTime(item.created_at)
+        );
 
         // data-label carries the column name into the stacked phone layout,
         // where the header row is hidden.
@@ -105,7 +106,7 @@
                 <td data-label="Doc ID">${docLink}</td>
                 <td data-label="Title" class="zr-truncate" title="${escHtml(item.title || '')}">${escHtml(item.title || '–')}</td>
                 <td data-label="Reason"><span class="zr-badge">${escHtml(item.reason || 'manual')}</span></td>
-                <td data-label="Added" class="zr-sm zr-faint" title="${addedTitle}">${added}</td>
+                <td data-label="Added" class="zr-sm zr-faint zr-table__date" title="${addedTitle}">${added}</td>
                 <td data-label="" class="zr-table__actions">
                     <div class="zr-row">
                         <button class="zr-btn ignored-unignore-btn" data-id="${item.document_id}" title="Remove from ignore list and allow scanning again">

--- a/public/js/modules/dashboard.js
+++ b/public/js/modules/dashboard.js
@@ -11,6 +11,7 @@ import { renderSpark } from './spark.js';
 import { renderBarList } from './bar-list.js';
 import { formatTimeAgo, updateScannerHealthBanner } from './scanner-health.js';
 import { escapeHtml } from './text-utils.js';
+import { formatDate } from './date-format.js';
 
 const STATS_URL = '/api/dashboard/stats';
 const STATUS_URL = '/api/processing-status';
@@ -83,16 +84,6 @@ function formatDocumentCount(value) {
   return `${formatNumber(numeric)} ${Math.abs(numeric) === 1 ? 'doc' : 'docs'}`;
 }
 
-function formatDate(value) {
-  if (!value) return 'unknown date';
-  const normalized = String(value).includes(' ')
-    ? String(value).replace(' ', 'T')
-    : String(value);
-  const parsed = new Date(normalized);
-  if (Number.isNaN(parsed.getTime())) return 'unknown date';
-  return parsed.toLocaleDateString();
-}
-
 async function fetchJson(url, options = {}) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -152,7 +143,7 @@ export default function dashboard(root, { toast }) {
               <span class="zr-list__title">${escapeHtml(item.title || 'Untitled document')}</span>
               <span class="zr-list__sub">${escapeHtml(item.correspondent || 'Unknown correspondent')} &middot; #${Number(item.documentId || 0)}</span>
             </span>
-            <span class="zr-list__time">${escapeHtml(formatDate(item.createdAt))}</span>
+            <span class="zr-list__time">${escapeHtml(formatDate(item.createdAt, { fallback: 'unknown date' }))}</span>
           </${tag}>`;
       })
       .join('');

--- a/public/js/modules/date-format.js
+++ b/public/js/modules/date-format.js
@@ -1,0 +1,22 @@
+/**
+ * The configured date formatter, for module land.
+ *
+ * The implementation lives in the classic script /js/date-format.js — the page
+ * scripts that render most of the tables cannot import an ES module, and one
+ * formatter beats two. This adapter is what lets a module name the dependency
+ * in its import list instead of reaching for a global halfway down a render
+ * function; the shell loads the script in <head>, so it is there by the time
+ * any module runs.
+ */
+
+export function formatDate(value, options) {
+  return window.zrDate
+    ? window.zrDate.format(value, options)
+    : (options && options.fallback) || '';
+}
+
+export function formatDateTime(value, options) {
+  return window.zrDate
+    ? window.zrDate.formatDateTime(value, options)
+    : (options && options.fallback) || '';
+}

--- a/public/js/ocr.js
+++ b/public/js/ocr.js
@@ -173,9 +173,10 @@
         // Date only: the exact second added nothing and its width forced the
         // table to scroll sideways on ordinary desktop windows. The full
         // timestamp stays reachable through the cell title.
-        const addedAt = item.added_at ? new Date(item.added_at) : null;
-        const addedDate = addedAt ? addedAt.toLocaleDateString() : '–';
-        const addedTitle = addedAt ? escHtml(addedAt.toLocaleString()) : '';
+        const addedDate = window.zrDate.format(item.added_at, {
+          fallback: '–',
+        });
+        const addedTitle = escHtml(window.zrDate.formatDateTime(item.added_at));
 
         // One labelled action per row, everything else behind the "…" — which
         // state a row is in decides what that primary action is, so the column
@@ -218,7 +219,7 @@
                 <td data-label="Title" class="zr-truncate" title="${escHtml(item.title || '')}">${escHtml(item.title || '–')}</td>
                 <td data-label="Reason"><span class="zr-badge">${reasonLabel}</span></td>
                 <td data-label="Status">${statusHtml}</td>
-                <td data-label="Added" class="zr-sm zr-faint" title="${addedTitle}">${addedDate}</td>
+                <td data-label="Added" class="zr-sm zr-faint zr-table__date" title="${addedTitle}">${addedDate}</td>
                 <td data-label="" class="zr-table__actions">
                     <div class="zr-row">
                         ${primaryBtn}

--- a/public/js/playground-analyzer.js
+++ b/public/js/playground-analyzer.js
@@ -369,7 +369,7 @@ class PromptRatingSystem {
                 </div>
                 <div class="prompt-text zr-sm zr-mono">${prompt.prompt}</div>
                 ${prompt.comment ? `<div class="zr-sm zr-muted">${prompt.comment}</div>` : ''}
-                <div class="zr-xs zr-faint">${new Date(prompt.date).toLocaleString()}</div>
+                <div class="zr-xs zr-faint">${window.zrDate.formatDateTime(prompt.date)}</div>
                 <div class="saved-prompt-card__actions">
                     <button onclick="window.promptRating.usePrompt(${prompt.id})" 
                             class="zr-btn zr-btn--primary"
@@ -472,10 +472,7 @@ class PlaygroundAnalyzer {
   }
 
   formatDocumentDate(dateValue) {
-    if (!dateValue) return 'Unknown date';
-    const parsed = new Date(dateValue);
-    if (Number.isNaN(parsed.getTime())) return 'Unknown date';
-    return parsed.toLocaleDateString();
+    return window.zrDate.format(dateValue, { fallback: 'Unknown date' });
   }
 
   renderDocuments(documents, tagNames = {}, correspondentNames = {}) {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -2780,6 +2780,7 @@ function initializeRuntimeOverridePills() {
     { selector: '#globalRateLimitMax', envKey: 'GLOBAL_RATE_LIMIT_MAX' },
     { selector: '#trustProxy', envKey: 'TRUST_PROXY' },
     { selector: '#cookieSecureMode', envKey: 'COOKIE_SECURE_MODE' },
+    { selector: '#dateFormat', envKey: 'DATE_FORMAT' },
     { selector: '#minContentLength', envKey: 'MIN_CONTENT_LENGTH' },
     { selector: '#paperlessAiPort', envKey: 'PAPERLESS_AI_PORT' },
     { selector: '#reconciliationEnabled', envKey: 'RECONCILIATION_ENABLED' },

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3797,6 +3797,10 @@ const ENV_EXPORT_GROUPS = [
       'ANONYMIZED_TELEMETRY',
     ],
   },
+  {
+    title: 'Interface',
+    keys: ['DATE_FORMAT'],
+  },
 ];
 
 /* A value only needs quoting when it carries something a .env parser would
@@ -6605,6 +6609,7 @@ router.get('/settings', async (req, res) => {
     MIN_CONTENT_LENGTH: process.env.MIN_CONTENT_LENGTH || '10',
     PAPERLESS_AI_PORT: process.env.PAPERLESS_AI_PORT || '3000',
     LOG_LEVEL: process.env.LOG_LEVEL || 'info',
+    DATE_FORMAT: process.env.DATE_FORMAT || 'DD.MM.YYYY',
   };
 
   if (isConfigured) {
@@ -8045,6 +8050,11 @@ router.get('/health', async (req, res) => {
  *                 type: string
  *                 description: Run AI analysis directly after automatic OCR (yes/no)
  *                 example: "yes"
+ *               dateFormat:
+ *                 type: string
+ *                 description: How every date in the web interface is rendered
+ *                 enum: ["DD.MM.YYYY", "YYYY-MM-DD"]
+ *                 example: "DD.MM.YYYY"
  *     responses:
  *       200:
  *         description: Settings updated successfully
@@ -8155,6 +8165,7 @@ router.post('/settings', express.json(), async (req, res) => {
       paperlessAiPort,
       externalApiAllowPrivateIps,
       logLevel,
+      dateFormat,
     } = req.body;
 
     //replace equal char in system prompt
@@ -8253,6 +8264,7 @@ router.post('/settings', express.json(), async (req, res) => {
       MIN_CONTENT_LENGTH: process.env.MIN_CONTENT_LENGTH || '10',
       PAPERLESS_AI_PORT: process.env.PAPERLESS_AI_PORT || '3000',
       LOG_LEVEL: process.env.LOG_LEVEL || 'info',
+      DATE_FORMAT: process.env.DATE_FORMAT || 'DD.MM.YYYY',
     };
 
     const hasValue = (value) =>
@@ -8710,6 +8722,19 @@ router.post('/settings', express.json(), async (req, res) => {
       } else {
         return res.status(400).json({
           error: 'Invalid Log Level. Allowed values: debug, info, warn, error.',
+        });
+      }
+    }
+    if (typeof dateFormat === 'string') {
+      // Upper-cased before the comparison because the value doubles as the
+      // pattern it describes — an operator typing dd.mm.yyyy into the .env file
+      // means the same thing the select does.
+      const normalizedDateFormat = dateFormat.trim().toUpperCase();
+      if (['DD.MM.YYYY', 'YYYY-MM-DD'].includes(normalizedDateFormat)) {
+        updatedConfig.DATE_FORMAT = normalizedDateFormat;
+      } else {
+        return res.status(400).json({
+          error: 'Invalid Date Format. Allowed values: DD.MM.YYYY, YYYY-MM-DD.',
         });
       }
     }

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -39,6 +39,7 @@ const TESTS = {
   'ignore-tags-filter': 'test-ignore-tags-filter.js',
   'injected-env-priority': 'test-injected-env-priority.js',
   'changelog-releases': 'test-changelog-releases.js',
+  'date-format-config': 'test-date-format-config.js',
   'log-level-config': 'test-log-level-config.js',
   'log-level-logger': 'test-log-level-logger.js',
   'native-install-log-paths': 'test-native-install-log-paths.js',
@@ -129,6 +130,7 @@ const AREAS = {
   ],
   observability: [
     'changelog-releases',
+    'date-format-config',
     'log-level-config',
     'log-level-logger',
     'native-install-log-paths',

--- a/server.js
+++ b/server.js
@@ -321,6 +321,7 @@ app.use((req, res, next) => {
   res.locals.appServerTimeUtc = new Date().toISOString();
   res.locals.appServerTimezone =
     Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  res.locals.appDateFormat = config.dateFormat || 'DD.MM.YYYY';
   res.locals.appPaperlessApiUrl = config.paperless?.apiUrl || 'unknown';
   res.locals.appOllamaApiUrl = config.ollama?.apiUrl || 'unknown';
   res.locals.appOllamaModel = config.ollama?.model || 'unknown';

--- a/tests/test-date-format-config.js
+++ b/tests/test-date-format-config.js
@@ -1,0 +1,217 @@
+/**
+ * Covers the configurable date format end to end — the half that decides which
+ * format is active (config/config.js) and the half that renders with it
+ * (public/js/date-format.js).
+ *
+ * The browser script is executed rather than grepped, because the whole point
+ * of the setting is what comes out the other side: a padded month. A test that
+ * only checked for the string 'padStart' would still pass with the padding
+ * applied to the wrong field.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let failed = 0;
+const check = (label, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${label}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`  ✗ ${label}: ${error.message}`);
+  }
+};
+
+/* --- which format is active ------------------------------------------- */
+
+const configModulePath = require.resolve('../config/config');
+const originalDateFormat = process.env.DATE_FORMAT;
+
+function loadConfigWithDateFormat(value) {
+  delete require.cache[configModulePath];
+
+  if (typeof value === 'undefined') {
+    delete process.env.DATE_FORMAT;
+  } else {
+    process.env.DATE_FORMAT = value;
+  }
+
+  return require('../config/config');
+}
+
+function restoreEnvironment() {
+  if (typeof originalDateFormat === 'undefined') {
+    delete process.env.DATE_FORMAT;
+  } else {
+    process.env.DATE_FORMAT = originalDateFormat;
+  }
+
+  delete require.cache[configModulePath];
+}
+
+check('keeps both offered formats', () => {
+  assert.strictEqual(
+    loadConfigWithDateFormat('YYYY-MM-DD').dateFormat,
+    'YYYY-MM-DD'
+  );
+  assert.strictEqual(
+    loadConfigWithDateFormat('DD.MM.YYYY').dateFormat,
+    'DD.MM.YYYY'
+  );
+});
+
+check('reads a hand-edited .env in any case', () => {
+  assert.strictEqual(
+    loadConfigWithDateFormat('yyyy-mm-dd').dateFormat,
+    'YYYY-MM-DD'
+  );
+  assert.strictEqual(
+    loadConfigWithDateFormat('  dd.mm.yyyy  ').dateFormat,
+    'DD.MM.YYYY'
+  );
+});
+
+check('falls back to DD.MM.YYYY when the value is unusable', () => {
+  assert.strictEqual(
+    loadConfigWithDateFormat('MM/DD/YYYY').dateFormat,
+    'DD.MM.YYYY'
+  );
+  assert.strictEqual(loadConfigWithDateFormat('').dateFormat, 'DD.MM.YYYY');
+  assert.strictEqual(
+    loadConfigWithDateFormat(undefined).dateFormat,
+    'DD.MM.YYYY'
+  );
+});
+
+check('writes the normalized value back onto the environment', () => {
+  // The settings view and the .env export both read process.env directly, so
+  // they would otherwise show the typo instead of what the app renders with.
+  loadConfigWithDateFormat('mm/dd/yyyy');
+  assert.strictEqual(process.env.DATE_FORMAT, 'DD.MM.YYYY');
+});
+
+const offeredFormats = loadConfigWithDateFormat(undefined).validDateFormats;
+restoreEnvironment();
+
+/* --- what the browser renders ----------------------------------------- */
+
+const formatterSource = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'js', 'date-format.js'),
+  'utf8'
+);
+
+/**
+ * @param {string|null} metaContent what the shell wrote into the meta tag,
+ *   null for a page that carries none.
+ */
+function loadSandbox(metaContent) {
+  const sandbox = {
+    document: {
+      querySelector(selector) {
+        if (selector !== 'meta[name="date-format"]' || metaContent === null) {
+          return null;
+        }
+        return { getAttribute: () => metaContent };
+      },
+    },
+  };
+  sandbox.window = sandbox;
+
+  vm.createContext(sandbox);
+  vm.runInContext(formatterSource, sandbox);
+
+  return sandbox;
+}
+
+function loadFormatter(metaContent) {
+  return loadSandbox(metaContent).window.zrDate;
+}
+
+// No timezone suffix anywhere below: the values are parsed as local time, so
+// the day stays the day whatever TZ the runner has.
+const SEPTEMBER_THIRD = '2026-09-03 07:05:09';
+const AUGUST_FIFTEENTH = '2026-08-15 14:32:05';
+
+check('pads the month and the day in the German format', () => {
+  const zrDate = loadFormatter('DD.MM.YYYY');
+  assert.strictEqual(zrDate.format(SEPTEMBER_THIRD), '03.09.2026');
+  assert.strictEqual(zrDate.format(AUGUST_FIFTEENTH), '15.08.2026');
+});
+
+check('pads the month and the day in the ISO format', () => {
+  const zrDate = loadFormatter('YYYY-MM-DD');
+  assert.strictEqual(zrDate.format(SEPTEMBER_THIRD), '2026-09-03');
+  assert.strictEqual(zrDate.format(AUGUST_FIFTEENTH), '2026-08-15');
+});
+
+check('appends a 24-hour clock under both formats', () => {
+  assert.strictEqual(
+    loadFormatter('DD.MM.YYYY').formatDateTime(AUGUST_FIFTEENTH),
+    '15.08.2026 14:32:05'
+  );
+  assert.strictEqual(
+    loadFormatter('YYYY-MM-DD').formatDateTime(SEPTEMBER_THIRD),
+    '2026-09-03 07:05:09'
+  );
+});
+
+check('renders every format the server is willing to hand it', () => {
+  // Guards the seam: a third format added to config/config.js without teaching
+  // the browser script would silently render as DD.MM.YYYY everywhere.
+  const rendered = offeredFormats.map((format) =>
+    loadFormatter(format).activeFormat()
+  );
+  assert.deepStrictEqual(rendered, offeredFormats);
+});
+
+check('accepts the shapes the endpoints actually return', () => {
+  const sandbox = loadSandbox('DD.MM.YYYY');
+  const { zrDate } = sandbox.window;
+
+  // SQLite hands out a space where ISO wants a T, and Safari refuses that.
+  assert.strictEqual(zrDate.format('2026-09-03 07:05:09'), '03.09.2026');
+  assert.strictEqual(zrDate.format('2026-09-03T07:05:09'), '03.09.2026');
+  assert.strictEqual(zrDate.format('2026-09-03'), '03.09.2026');
+
+  // Built inside the sandbox on purpose: a Date from this file belongs to
+  // another realm, where `instanceof Date` is false for reasons that have
+  // nothing to do with the browser the code actually runs in.
+  assert.strictEqual(
+    vm.runInContext('window.zrDate.format(new Date(2026, 8, 3))', sandbox),
+    '03.09.2026'
+  );
+});
+
+check('leaves the empty cell to its caller', () => {
+  const zrDate = loadFormatter('DD.MM.YYYY');
+  assert.strictEqual(zrDate.format(null), '');
+  assert.strictEqual(zrDate.format(''), '');
+  assert.strictEqual(zrDate.format(undefined, { fallback: '–' }), '–');
+  assert.strictEqual(zrDate.format('not a date', { fallback: '–' }), '–');
+  assert.strictEqual(
+    zrDate.formatDateTime(null, { fallback: 'Unknown' }),
+    'Unknown'
+  );
+});
+
+check('falls back when the page says something unexpected', () => {
+  assert.strictEqual(
+    loadFormatter('MM/DD/YYYY').format(SEPTEMBER_THIRD),
+    '03.09.2026'
+  );
+  assert.strictEqual(loadFormatter(null).format(SEPTEMBER_THIRD), '03.09.2026');
+  assert.strictEqual(
+    loadFormatter('yyyy-mm-dd').format(SEPTEMBER_THIRD),
+    '2026-09-03'
+  );
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} date format case(s) failed`);
+  process.exit(1);
+}
+
+console.log('\nAll date format cases passed');

--- a/tests/test-env-export.js
+++ b/tests/test-env-export.js
@@ -123,6 +123,7 @@ check('emits every group when everything is configured', () => {
     MISTRAL_OCR_ENABLED: 'yes',
     API_KEY: 'abc',
     LOG_LEVEL: 'debug',
+    DATE_FORMAT: 'YYYY-MM-DD',
   });
   [
     '# Paperless-ngx connection',
@@ -133,6 +134,7 @@ check('emits every group when everything is configured', () => {
     '# OCR fallback',
     '# Server and security',
     '# Maintenance',
+    '# Interface',
   ].forEach((heading) => assert.ok(env.includes(heading), heading));
 });
 

--- a/views/partials/shell/head-start.ejs
+++ b/views/partials/shell/head-start.ejs
@@ -2,6 +2,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="<%= typeof csrfToken !== 'undefined' ? csrfToken : '' %>">
+    <!-- How /js/date-format.js renders every date on the page. A meta tag rather than a data attribute on <html>, because the theme script already owns that element and rewrites it before first paint. -->
+    <meta name="date-format" content="<%= typeof appDateFormat !== 'undefined' && appDateFormat ? appDateFormat : 'DD.MM.YYYY' %>">
     <title><%= typeof pageTitle !== 'undefined' ? pageTitle : 'Zettelrobbe' %></title>
     <link rel="icon" type="image/webp" href="/favicon.webp">
     <%- include('theme-init-head') %>
@@ -27,3 +29,4 @@
     <link rel="stylesheet" href="/css/pages/shared.css">
     <link rel="stylesheet" href="/css/utilities.css">
     <script src="/js/csrf.js"></script>
+    <script src="/js/date-format.js"></script>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -222,6 +222,24 @@
                                 </div>
                             </section>
 
+                            <section class="zr-module" id="sec-display">
+                                <div class="zr-module__head">
+                                    <h2 class="zr-module__title">Display</h2>
+                                </div>
+                                <div class="zr-module__body zr-col zr-col--loose">
+                                <div class="zr-formgrid">
+                                    <div class="zr-field zr-field--stacked">
+                                        <label for="dateFormat" class="zr-field__name">Date Format</label>
+                                        <select id="dateFormat" name="dateFormat" class="zr-input">
+                                            <option value="DD.MM.YYYY" <%= String(config.DATE_FORMAT || 'DD.MM.YYYY').toUpperCase() === 'YYYY-MM-DD' ? '' : 'selected' %>>DD.MM.YYYY</option>
+                                            <option value="YYYY-MM-DD" <%= String(config.DATE_FORMAT || 'DD.MM.YYYY').toUpperCase() === 'YYYY-MM-DD' ? 'selected' : '' %>>YYYY-MM-DD</option>
+                                        </select>
+                                        <p class="zr-field__hint">Every date in the interface: 15 August 2026 reads as 15.08.2026 or 2026-08-15 &middot; Restart required</p>
+                                    </div>
+                                </div>
+                                </div>
+                            </section>
+
                         </div>
 
                         <div id="mfa-tab" class="zr-col zr-col--loose">

--- a/views/styleguide.ejs
+++ b/views/styleguide.ejs
@@ -1010,7 +1010,7 @@
                                         <td data-label="Doc ID">1281</td>
                                         <td data-label="Title" class="zr-truncate">Utility statement August 2026 — a title long enough to need the ellipsis</td>
                                         <td data-label="Source"><span class="zr-warn-text">OCR</span></td>
-                                        <td data-label="Updated">2026-08-12 06:41</td>
+                                        <td data-label="Updated" class="zr-table__date">2026-08-12 06:41</td>
                                         <td data-label="" class="zr-table__actions">
                                             <div class="zr-row">
                                                 <button type="button" class="zr-btn">
@@ -1044,7 +1044,7 @@
                                         <td data-label="Doc ID">1280</td>
                                         <td data-label="Title" class="zr-truncate">Insurance policy renewal — household</td>
                                         <td data-label="Source">AI</td>
-                                        <td data-label="Updated">2026-08-11 18:12</td>
+                                        <td data-label="Updated" class="zr-table__date">2026-08-11 18:12</td>
                                         <td data-label="" class="zr-table__actions">
                                             <div class="zr-row">
                                                 <button type="button" class="zr-btn">


### PR DESCRIPTION
Dates were rendered with `toLocaleDateString()`, so what a table showed depended on the browser's locale rather than on anything the instance could set — and a German browser drops the leading zero, which is how one column ended up mixing `15.8.2026` with `03.09.2026`. Nine call sites across six files each decided this for themselves.

## The setting

`DATE_FORMAT` picks between **DD.MM.YYYY** and **YYYY-MM-DD**, offered as a *Display* section in the System tab. Both pad month and day to two digits, and both carry a 24-hour clock in the full timestamps behind the cell titles — the choice is about the order of the date parts, and an am/pm time belongs to neither.

The value is normalized in `config/config.js`: case-insensitive, so a hand-edited `.env` reading `yyyy-mm-dd` works, and anything unknown falls back with a warning instead of breaking a render. It is written back onto `process.env`, because the settings view and the `.env` export both read that directly and would otherwise show the operator's typo rather than what the app renders with. The export gained an *Interface* group for it.

## How it reaches the browser

The shell writes the choice into a `<meta name="date-format">` tag. The implementation is the classic script `public/js/date-format.js` — the page scripts that build the tables cannot import an ES module, and one formatter beats two; `modules/date-format.js` is the twelve-line adapter that lets module land keep its import list honest instead of reaching for a global halfway down a render function.

Parsing accepts what the endpoints actually return: ISO strings, SQLite's `YYYY-MM-DD HH:MM:SS` (which Safari refuses over the space), `Date` objects and epoch milliseconds. Anything else returns empty and the caller supplies its own wording, so every existing placeholder — `–`, `unknown date`, `Unknown` — survived unchanged.

Every date now goes through it: dashboard activity, history rows and modal, the OCR, failed and ignored queues, the document omnibox pill, the playground.

## What the switch exposed

`YYYY-MM-DD` offers the browser two break opportunities at its hyphens and it takes them as soon as a column is tight. The same row that read `03.09.2026` on one line came back as `2026-` / `09-03` on two, with the row height to match. The date cells carry `.zr-table__date` now, following `.zr-table__actions`, which exists for the same reason one column over. It is in the styleguide so the next table finds it.

## Testing

- `node scripts/run-tests.js --all` — 64 passed / 6 skipped (server-dependent) / 0 failed.
- The new offline test runs the browser script in a `vm` against a stubbed meta tag and asserts the rendered strings, so the padding is checked where it is produced rather than grepped for. One case renders every format `config.js` is willing to hand out, which fails if a third format is added server-side without teaching the browser.
- Both formats were driven in a browser at 1280px and 375px across settings, dashboard, history, ocr, failed and ignored — with rows, and with a row whose date is missing.
- eslint, prettier and stylelint clean on every touched file; no OpenAPI drift.

## Impact

Existing instances render `DD.MM.YYYY`, which is what a German browser already showed apart from the missing zero; an en-US browser changes from `8/15/2026`. Saving the setting restarts the app, as every setting on that page does.

Branched fresh from `nightly` — #288 was squash-merged, so its branch could not carry this without dragging the whole diff along again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
