### PR TITLE
Run OCR and the analysis from the history row

### DIFF
--- a/public/js/history.js
+++ b/public/js/history.js
@@ -6,6 +6,11 @@ class HistoryManager {
     this.confirmModalAll = document.getElementById('confirmModalAll');
     this.selectAll = document.getElementById('selectAll');
     this.table = null; // Will be initialized in initializeDataTable
+    // Server-rendered: the row menu is built here, but whether OCR is
+    // configured at all is only known on the server.
+    this.ocrEnabled =
+      document.getElementById('historyTableContainer')?.dataset.ocrEnabled ===
+      'yes';
     this.initialize();
   }
 
@@ -291,8 +296,16 @@ class HistoryManager {
               `<button type="button" class="zr-menu__item history-chat-btn" data-docid="${docId}">` +
               '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-comment"/></svg>Chat about this document</button>' +
               '<div class="zr-menu__sep"></div>' +
-              `<button type="button" class="zr-menu__item history-ocr-btn" data-docid="${docId}">` +
-              '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-scan"/></svg>Send to OCR queue</button>' +
+              // Both OCR entries are dropped when the fallback is switched
+              // off: queueing a document nothing will ever process, and
+              // offering a run that answers "OCR is not enabled", are two ways
+              // of wasting the same click.
+              (this.ocrEnabled
+                ? `<button type="button" class="zr-menu__item history-ocr-run-btn" data-docid="${docId}">` +
+                  '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-play"/></svg>OCR now, then analyze</button>' +
+                  `<button type="button" class="zr-menu__item history-ocr-btn" data-docid="${docId}">` +
+                  '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-scan"/></svg>Send to OCR queue</button>'
+                : '') +
               `<button type="button" class="zr-menu__item history-rescan-btn" data-docid="${docId}">` +
               '<svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-refresh"/></svg>Reanalyze</button>' +
               '<div class="zr-menu__sep"></div>' +
@@ -517,6 +530,19 @@ class HistoryManager {
       button.dataset.boundClick = 'true';
     });
 
+    document.querySelectorAll('.history-ocr-run-btn').forEach((button) => {
+      if (button.dataset.boundClick === 'true') return;
+      button.addEventListener('click', () => {
+        const docId = button.dataset.docid || '';
+        if (!/^\d+$/.test(docId)) {
+          console.warn('Blocked unsafe document id:', docId);
+          return;
+        }
+        this.ocrAndAnalyze(Number(docId));
+      });
+      button.dataset.boundClick = 'true';
+    });
+
     document.querySelectorAll('.history-ocr-btn').forEach((button) => {
       if (button.dataset.boundClick === 'true') return;
       button.addEventListener('click', () => {
@@ -556,6 +582,56 @@ class HistoryManager {
         this.ignoreDocument(Number(docId), button.dataset.title || '');
       });
       button.dataset.boundClick = 'true';
+    });
+  }
+
+  /**
+   * Runs OCR for one document now and lets the AI analysis follow, from the row
+   * the operator is already looking at. Queueing and then walking to the OCR
+   * page to press Process was the only route before.
+   *
+   * The queue entry is created first even though processQueueItem() does not
+   * insist on one: the extracted text is stored on that row, and without it the
+   * OCR page — where the output is read back — would never learn the document
+   * had been through.
+   */
+  async ocrAndAnalyze(documentId) {
+    try {
+      const response = await fetch('/api/ocr/queue/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ documentId }),
+      });
+
+      // A 200 carrying success:false only means the document was in the queue
+      // already, which is the ordinary case here. Anything else is a real
+      // refusal — an unknown document, a bad id — and stops the run.
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(
+          data?.error ||
+            `Could not queue the document (HTTP ${response.status})`
+        );
+      }
+    } catch (error) {
+      this.showToast(`OCR could not be started: ${error.message}`, 'error');
+      return;
+    }
+
+    if (!window.zrOcrProgress) {
+      this.showToast('The progress overlay is unavailable.', 'error');
+      return;
+    }
+
+    window.zrOcrProgress.run({
+      url: `/api/ocr/process/${documentId}`,
+      // The whole point of this entry over the queue one: the operator wants
+      // the finished result, not an OCR text to analyze from another page.
+      body: { autoAnalyze: true },
+      title: `OCR and analysis for document #${documentId}`,
+      onDone: (ok) => {
+        if (ok) this.table?.reload();
+      },
     });
   }
 

--- a/public/js/ocr-progress.js
+++ b/public/js/ocr-progress.js
@@ -1,0 +1,199 @@
+/**
+ * The OCR run overlay: a progress bar and a live log fed by an SSE endpoint.
+ *
+ * A classic script publishing a global, because both of its callers cannot
+ * share anything else — ocr.js is a classic script and history.js is an ES
+ * module. The markup it drives is views/partials/ocr-progress-overlay.ejs, and
+ * its styling lives in css/pages/queues.css; a page that wants this needs both.
+ *
+ *   window.zrOcrProgress.run({
+ *     url: '/api/ocr/process/42',
+ *     body: { autoAnalyze: true },
+ *     title: 'OCR for document #42',
+ *     onDone: (ok) => { ... },
+ *   });
+ */
+(function () {
+  'use strict';
+
+  // download, ocr, writeback, ai — the four the endpoints report.
+  const TOTAL_STEPS = 4;
+
+  const STEP_ICONS = {
+    download: '⬇ ',
+    ocr: '🔍 ',
+    writeback: '📤 ',
+    ai: '🤖 ',
+    done: '✅ ',
+    error: '❌ ',
+    start: '▶ ',
+    progress: '· ',
+    item_download: '  ⬇ ',
+    item_ocr: '  🔍 ',
+    item_writeback: '  📤 ',
+    item_ai: '  🤖 ',
+    item_done: '  ✅ ',
+    item_error: '  ❌ ',
+  };
+
+  // Looked up per call rather than at load: the overlay markup sits at the end
+  // of the page, and this script is free to be loaded before it.
+  const el = (id) => document.getElementById(id);
+
+  function open(title) {
+    const overlay = el('progressOverlay');
+    const log = el('progressLog');
+    const bar = el('progressBar');
+
+    if (el('progressTitle')) el('progressTitle').textContent = title;
+    if (log) log.innerHTML = '';
+    if (bar) {
+      bar.style.width = '5%';
+      bar.classList.remove('zr-meter__fill--ok', 'zr-meter__fill--danger');
+    }
+    if (el('progressCloseBtn')) el('progressCloseBtn').style.display = 'none';
+    if (el('progressDoneBtn')) el('progressDoneBtn').style.display = 'none';
+    if (overlay) overlay.style.display = 'flex';
+  }
+
+  function close() {
+    const overlay = el('progressOverlay');
+    if (overlay) overlay.style.display = 'none';
+  }
+
+  function finalize(isError) {
+    const bar = el('progressBar');
+    if (bar) {
+      bar.style.width = '100%';
+      // Assigning the whole className used to drop zr-meter__fill along with
+      // the Tailwind classes it replaced, so the bar vanished at 100%.
+      bar.classList.toggle('zr-meter__fill--danger', Boolean(isError));
+      bar.classList.toggle('zr-meter__fill--ok', !isError);
+    }
+    if (el('progressCloseBtn')) el('progressCloseBtn').style.display = 'block';
+    if (el('progressDoneBtn')) el('progressDoneBtn').style.display = 'block';
+  }
+
+  function setProgress(pct) {
+    const bar = el('progressBar');
+    if (bar) bar.style.width = `${pct}%`;
+  }
+
+  function appendLog(step, message) {
+    const log = el('progressLog');
+    if (!log) return;
+
+    const line = document.createElement('div');
+    line.className = `log-line log-${step}`;
+    line.textContent = (STEP_ICONS[step] || '  ') + message;
+    log.appendChild(line);
+    log.scrollTop = log.scrollHeight;
+  }
+
+  /**
+   * Runs one SSE job and reports into the overlay.
+   *
+   * The stream is read with fetch rather than EventSource because the endpoints
+   * take a POST body (autoAnalyze), which EventSource cannot send.
+   */
+  function run({ url, body = {}, title = 'Processing…', onDone = null }) {
+    open(title);
+
+    let stepsDone = 0;
+    const settle = (ok) => {
+      finalize(!ok);
+      if (onDone) onDone(ok);
+    };
+
+    const handleEvent = (event) => {
+      const step = event.step || 'info';
+      const message = event.message || '';
+
+      appendLog(step, message);
+
+      if (
+        ['download', 'ocr', 'writeback', 'ai'].includes(step) &&
+        message &&
+        !message.startsWith('[OCR]')
+      ) {
+        // Count completions roughly: the "…" lines announce a step, the plain
+        // ones report it finished.
+        if (
+          !message.includes('…') &&
+          !message.includes('Sending') &&
+          !message.includes('Writing') &&
+          !message.includes('Starting')
+        ) {
+          stepsDone = Math.min(stepsDone + 1, TOTAL_STEPS);
+          setProgress(Math.round((stepsDone / TOTAL_STEPS) * 90));
+        }
+      }
+
+      if (step === 'done') {
+        setProgress(100);
+        settle(true);
+      }
+      if (step === 'error') {
+        settle(false);
+      }
+    };
+
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        const read = () => {
+          reader
+            .read()
+            .then(({ done, value }) => {
+              if (done) {
+                settle(true);
+                return;
+              }
+
+              buffer += decoder.decode(value, { stream: true });
+              const lines = buffer.split('\n');
+              buffer = lines.pop(); // keep the incomplete line
+
+              for (const line of lines) {
+                if (!line.startsWith('data:')) continue;
+                try {
+                  handleEvent(JSON.parse(line.slice(5).trim()));
+                } catch {
+                  // Ignore partial or malformed SSE frames.
+                }
+              }
+
+              read();
+            })
+            .catch((error) => {
+              appendLog('error', `Connection error: ${error.message}`);
+              settle(false);
+            });
+        };
+
+        read();
+      })
+      .catch((error) => {
+        appendLog('error', error.message);
+        settle(false);
+      });
+  }
+
+  // The two dismiss buttons belong to the overlay, so they are wired here
+  // rather than by every page that includes it.
+  document.addEventListener('click', (event) => {
+    const target = event.target.closest('#progressCloseBtn, #progressDoneBtn');
+    if (target) close();
+  });
+
+  window.zrOcrProgress = { run, open, close, appendLog, setProgress, finalize };
+})();

--- a/public/js/ocr.js
+++ b/public/js/ocr.js
@@ -27,14 +27,6 @@
   const processAllBtn = document.getElementById('processAllBtn');
   const autoAnalyze = document.getElementById('autoAnalyzeToggle');
 
-  // Progress overlay
-  const overlay = document.getElementById('progressOverlay');
-  const progressLog = document.getElementById('progressLog');
-  const progressBar = document.getElementById('progressBar');
-  const progressTitle = document.getElementById('progressTitle');
-  const closeBtn = document.getElementById('progressCloseBtn');
-  const doneBtn = document.getElementById('progressDoneBtn');
-
   // ── Init ───────────────────────────────────────────────────────────────
   document.addEventListener('DOMContentLoaded', function () {
     const urlParams = new URLSearchParams(window.location.search);
@@ -78,9 +70,6 @@
           loadQueue();
         }
       });
-
-    if (closeBtn) closeBtn.addEventListener('click', closeOverlay);
-    if (doneBtn) doneBtn.addEventListener('click', closeOverlay);
   });
 
   // ── Load queue ─────────────────────────────────────────────────────────
@@ -444,58 +433,50 @@
     }
   }
 
+  // The overlay and the SSE reader live in /js/ocr-progress.js, which the
+  // history page drives as well.
+  const progress = () => window.zrOcrProgress;
+
+  const refreshAfterRun = (done) => {
+    if (done) {
+      loadQueue();
+      loadStats();
+    }
+  };
+
   // ── Process single ─────────────────────────────────────────────────────
   function processSingle(documentId) {
-    const autoAnalyzeVal = autoAnalyze ? autoAnalyze.checked : false;
-    openOverlay(`Processing Document #${documentId}…`);
-
-    const es = new EventSource(`/api/ocr/process/${documentId}`);
-    // SSE doesn't support POST natively; use fetch + ReadableStream instead
-    es.close();
-
-    fetchSSE(
-      `/api/ocr/process/${documentId}`,
-      { autoAnalyze: autoAnalyzeVal },
-      function (done) {
-        if (done) {
-          loadQueue();
-          loadStats();
-        }
-      }
-    );
+    progress().run({
+      url: `/api/ocr/process/${documentId}`,
+      body: { autoAnalyze: autoAnalyze ? autoAnalyze.checked : false },
+      title: `Processing Document #${documentId}…`,
+      onDone: refreshAfterRun,
+    });
   }
 
   // ── Process all ────────────────────────────────────────────────────────
   function processAll() {
-    const autoAnalyzeVal = autoAnalyze ? autoAnalyze.checked : false;
-    openOverlay('Processing All Pending Items…');
-
-    fetchSSE(
-      '/api/ocr/process-all',
-      { autoAnalyze: autoAnalyzeVal },
-      function (done) {
-        if (done) {
-          loadQueue();
-          loadStats();
-        }
-      }
-    );
+    progress().run({
+      url: '/api/ocr/process-all',
+      body: { autoAnalyze: autoAnalyze ? autoAnalyze.checked : false },
+      title: 'Processing All Pending Items…',
+      onDone: refreshAfterRun,
+    });
   }
 
   // ── AI only (existing OCR text) ───────────────────────────────────────
   function analyzeSingle(documentId) {
-    openOverlay(`AI Analysis for Document #${documentId}…`);
-    fetchSSE(`/api/ocr/analyze/${documentId}`, {}, function (done) {
-      if (done) {
-        loadQueue();
-        loadStats();
-      }
+    progress().run({
+      url: `/api/ocr/analyze/${documentId}`,
+      title: `AI Analysis for Document #${documentId}…`,
+      onDone: refreshAfterRun,
     });
   }
 
   // ── OCR output info ───────────────────────────────────────────────────
   async function showOcrInfo(documentId) {
-    openOverlay(`OCR Output for Document #${documentId}`);
+    const { open, setProgress, appendLog, finalize } = progress();
+    open(`OCR Output for Document #${documentId}`);
     setProgress(100);
     try {
       const resp = await fetch(`/api/ocr/queue/${documentId}/text`);
@@ -506,7 +487,7 @@
 
       if (!data.hasOcrText) {
         appendLog('error', 'No OCR text available for this document.');
-        finalizeOverlay(true);
+        finalize(true);
         return;
       }
 
@@ -520,159 +501,11 @@
           ? `${text.slice(0, 12000)}\n\n[... truncated ...]`
           : text;
       appendLog('progress', preview);
-      finalizeOverlay();
+      finalize();
     } catch (error) {
       appendLog('error', error.message);
-      finalizeOverlay(true);
+      finalize(true);
     }
-  }
-
-  // ── SSE via fetch (POST) ───────────────────────────────────────────────
-  function fetchSSE(url, body, onDone) {
-    const totalSteps = 4;
-    let stepsDone = 0;
-
-    fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-      .then((resp) => {
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const reader = resp.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-
-        function read() {
-          reader
-            .read()
-            .then(({ done, value }) => {
-              if (done) {
-                finalizeOverlay();
-                if (onDone) onDone(true);
-                return;
-              }
-              buffer += decoder.decode(value, { stream: true });
-              const lines = buffer.split('\n');
-              buffer = lines.pop(); // keep incomplete line
-              for (const line of lines) {
-                if (!line.startsWith('data:')) continue;
-                try {
-                  const event = JSON.parse(line.slice(5).trim());
-                  handleEvent(event);
-                } catch {
-                  // Ignore partial or malformed SSE frames.
-                }
-              }
-              read();
-            })
-            .catch((err) => {
-              appendLog('error', `Connection error: ${err.message}`);
-              finalizeOverlay();
-              if (onDone) onDone(false);
-            });
-        }
-        read();
-
-        function handleEvent(ev) {
-          const step = ev.step || 'info';
-          const msg = ev.message || '';
-
-          appendLog(step, msg);
-
-          if (
-            ['download', 'ocr', 'writeback', 'ai'].includes(step) &&
-            msg &&
-            !msg.startsWith('[OCR]')
-          ) {
-            // count step completions roughly
-            if (
-              !msg.includes('…') &&
-              !msg.includes('Sending') &&
-              !msg.includes('Writing') &&
-              !msg.includes('Starting')
-            ) {
-              stepsDone = Math.min(stepsDone + 1, totalSteps);
-              setProgress(Math.round((stepsDone / totalSteps) * 90));
-            }
-          }
-          if (step === 'done') {
-            setProgress(100);
-            finalizeOverlay();
-            if (onDone) onDone(true);
-          }
-          if (step === 'error') {
-            finalizeOverlay(true);
-            if (onDone) onDone(false);
-          }
-        }
-      })
-      .catch((err) => {
-        appendLog('error', err.message);
-        finalizeOverlay(true);
-        if (onDone) onDone(false);
-      });
-  }
-
-  // ── Overlay helpers ────────────────────────────────────────────────────
-  function openOverlay(title) {
-    if (progressTitle) progressTitle.textContent = title;
-    if (progressLog) progressLog.innerHTML = '';
-    if (progressBar) {
-      progressBar.style.width = '5%';
-      progressBar.classList.remove(
-        'zr-meter__fill--ok',
-        'zr-meter__fill--danger'
-      );
-    }
-    if (closeBtn) closeBtn.style.display = 'none';
-    if (doneBtn) doneBtn.style.display = 'none';
-    if (overlay) overlay.style.display = 'flex';
-  }
-
-  function closeOverlay() {
-    if (overlay) overlay.style.display = 'none';
-  }
-
-  function finalizeOverlay(isError) {
-    if (progressBar) {
-      progressBar.style.width = '100%';
-      // Assigning the whole className used to drop zr-meter__fill along with
-      // the Tailwind classes it replaced, so the bar vanished at 100%.
-      progressBar.classList.toggle('zr-meter__fill--danger', isError);
-      progressBar.classList.toggle('zr-meter__fill--ok', !isError);
-    }
-    if (closeBtn) closeBtn.style.display = 'block';
-    if (doneBtn) doneBtn.style.display = 'block';
-  }
-
-  function setProgress(pct) {
-    if (progressBar) progressBar.style.width = `${pct}%`;
-  }
-
-  function appendLog(step, message) {
-    if (!progressLog) return;
-    const line = document.createElement('div');
-    line.className = `log-line log-${step}`;
-    const icons = {
-      download: '⬇ ',
-      ocr: '🔍 ',
-      writeback: '📤 ',
-      ai: '🤖 ',
-      done: '✅ ',
-      error: '❌ ',
-      start: '▶ ',
-      progress: '· ',
-      item_download: '  ⬇ ',
-      item_ocr: '  🔍 ',
-      item_writeback: '  📤 ',
-      item_ai: '  🤖 ',
-      item_done: '  ✅ ',
-      item_error: '  ❌ ',
-    };
-    line.textContent = (icons[step] || '  ') + message;
-    progressLog.appendChild(line);
-    progressLog.scrollTop = progressLog.scrollHeight;
   }
 
   // ── Toast ──────────────────────────────────────────────────────────────

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -77,7 +77,9 @@
                 </div>
 
                 <!-- DataTable -->
-                <div id="historyTableContainer" class="zr-module" data-module="row-menu" style="display: none;">
+                <div id="historyTableContainer" class="zr-module" data-module="row-menu"
+                    data-ocr-enabled="<%= typeof appOcrEnabled !== 'undefined' && appOcrEnabled ? 'yes' : 'no' %>"
+                    style="display: none;">
                     <div class="zr-module__head">
                         <label class="zr-row zr-sm">
                             <input type="checkbox" id="selectAll" class="zr-check">
@@ -227,5 +229,10 @@
             </div>
         </div>
     </div>
+    <%- include('partials/ocr-progress-overlay') %>
+
+    <!-- Classic script: history.js is a module and can read the global it sets,
+         but the OCR queue page cannot import one. -->
+    <script src="/js/ocr-progress.js"></script>
     <script type="module" src="/js/history.js"></script>
     <%- include('partials/shell/body-close') %>

--- a/views/ocr.ejs
+++ b/views/ocr.ejs
@@ -140,32 +140,10 @@ MISTRAL_OCR_MODEL=mistral-ocr-latest</pre>
 
             </div>
 
-    <!-- Progress Overlay (SSE) -->
-    <div id="progressOverlay" style="display:none;">
-        <div id="progressBox">
-            <div class="zr-row zr-row--between">
-                <h3 id="progressTitle" class="zr-module__title">Processing…</h3>
-                <button id="progressCloseBtn" class="zr-btn" style="display:none;" aria-label="Close progress overlay">
-                    <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-x"/></svg>
-                </button>
-            </div>
-
-            <!-- Progress bar -->
-            <div class="zr-meter">
-                <div id="progressBar" class="zr-meter__fill" style="width:0%"></div>
-            </div>
-
-            <div id="progressLog"></div>
-
-            <div class="zr-row">
-                <button id="progressDoneBtn" class="zr-btn zr-btn--primary" style="display:none;">
-                    Close
-                </button>
-            </div>
-        </div>
-    </div>
+    <%- include('partials/ocr-progress-overlay') %>
 
     <%- include('partials/scripts/ocr-scripts') %>
     <script src="/js/document-omnibox.js"></script>
+    <script src="/js/ocr-progress.js"></script>
     <script src="/js/ocr.js"></script>
     <%- include('partials/shell/body-close') %>

--- a/views/partials/ocr-progress-overlay.ejs
+++ b/views/partials/ocr-progress-overlay.ejs
@@ -1,0 +1,26 @@
+<!-- OCR run overlay. Driven by /js/ocr-progress.js, styled in css/pages/queues.css;
+     a page that includes this needs the script too. Shared by the OCR queue and
+     the history list, which both start the same SSE job. -->
+<div id="progressOverlay" style="display:none;">
+    <div id="progressBox">
+        <div class="zr-row zr-row--between">
+            <h3 id="progressTitle" class="zr-module__title">Processing…</h3>
+            <button id="progressCloseBtn" class="zr-btn" style="display:none;" aria-label="Close progress overlay">
+                <svg class="zr-icon zr-icon--sm" aria-hidden="true"><use href="/icons.svg#i-x"/></svg>
+            </button>
+        </div>
+
+        <!-- Progress bar -->
+        <div class="zr-meter">
+            <div id="progressBar" class="zr-meter__fill" style="width:0%"></div>
+        </div>
+
+        <div id="progressLog"></div>
+
+        <div class="zr-row">
+            <button id="progressDoneBtn" class="zr-btn zr-btn--primary" style="display:none;">
+                Close
+            </button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
The history row menu could queue a document for OCR, and that was all. To see anything happen the operator had to walk to the OCR queue page, find the row again and press Process — with the auto-analyze toggle set, or the extracted text just sat there. Three screens for one intention.

The endpoint for doing it in one go already existed: `POST /api/ocr/process/:documentId` takes `{ autoAnalyze }` and streams its progress. Only the OCR page knew about it.

## The entry

**"OCR now, then analyze"** sits above the queue entry and runs that endpoint with `autoAnalyze` fixed to `true` — the entry exists precisely for the operator who wants the finished result, not an OCR text to analyze from somewhere else. The queue entry stays for the batch workflow.

A queue row is created first even though `processQueueItem()` does not insist on one: the extracted text is stored on that row, and without it the OCR page — where the output is read back — would never learn the document had been through. A 200 carrying `success:false` only means it was queued already, which is the ordinary case here; anything else stops the run.

Both OCR entries disappear when the fallback is switched off. Queueing a document nothing will ever process, and offering a run that answers "OCR is not enabled", are two ways of wasting the same click. The flag reaches the client through a data attribute, because the menu is built in the browser and only the server knows the configuration.

## The overlay moved rather than being copied

The progress markup is now `views/partials/ocr-progress-overlay.ejs` and the behaviour `public/js/ocr-progress.js`, publishing `window.zrOcrProgress`.

A classic script publishing a global is what the two callers can share: `ocr.js` is a classic script and `history.js` is an ES module, so neither can import from the other — the same bridge `document-omnibox.js` already uses for two pages. `ocr.js` lost **148 lines** to the move and now drives the same runner; its own dismiss-button wiring went with it, since those buttons belong to the overlay.

## Testing

Both pages were driven in a browser against an SSE stub.

- **From history:** the overlay opens, logs all four steps with `autoAnalyze=true` reaching the server, finishes green and reloads the table.
- **From the OCR queue:** Process still opens the same overlay and completes identically — the refactor is the part of this that could have broken something that worked.
- With OCR disabled the menu shows four entries instead of six.
- At 375px the run starts from the card surface (`historyRowMenu-card-42`) and the overlay fits the viewport without horizontal overflow.
- Suite unchanged at 64 passed / 6 skipped / 0 failed; eslint, prettier and stylelint clean on every touched file; no OpenAPI drift.

## Impact

No API change, no new endpoint, no migration. The queue-only entry keeps working for anyone using it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
