### PR TITLE
Release v2026.08.03

### DIFF
--- a/config/changelog.js
+++ b/config/changelog.js
@@ -83,6 +83,18 @@ const RELEASES = [
       "New: Settings has a Changelog tab showing the full release history, so past release notes are readable after the What's New modal has been dismissed",
     ],
   },
+  {
+    version: 'v2026.08.03',
+    entries: [
+      'New: Dashboard widgets can be rearranged, resized and hidden in an explicit edit mode',
+      'New: The date format is configurable between DD.MM.YYYY and YYYY-MM-DD under Settings &rarr; System &rarr; Display',
+      'New: History rows can start OCR with AI analysis directly, and send a document to Reanalyze or Ignore',
+      'Fix: The "Response Tokens" setting is applied as the AI response limit - Ollama was capped at 256 tokens regardless of it, which cut long answers off mid-sentence <a href="https://github.com/admonstrator/zettelrobbe/issues/263">(see here)</a>',
+      'Fix: An AI answer that was cut off is reported as a failed document instead of being silently marked processed with nothing extracted',
+      'Improvement: The dashboard serves its statistics from a cache instead of querying Paperless-ngx on every request',
+      'Improvement: The tag cache is rebuilt in two requests instead of one per 25 tags, which could stall startup for a minute on large libraries',
+    ],
+  },
 ];
 
 const latestRelease = RELEASES[RELEASES.length - 1];

--- a/config/config.js
+++ b/config/config.js
@@ -413,7 +413,7 @@ startupLog(logLevel, 'info', 'Configuration loaded:', {
 });
 
 module.exports = {
-  PAPERLESS_AI_VERSION: 'v2026.08.02',
+  PAPERLESS_AI_VERSION: 'v2026.08.03',
   CONFIGURED: false,
   configSourceMode: CONFIG_SOURCE_MODE,
   getApiKey,


### PR DESCRIPTION
Seven changelog entries covering what a user would notice since v2026.08.02 — the dashboard edit mode, the configurable date format, the new history OCR action, the two truncation fixes and the two caches — rather than one entry per merge. `PAPERLESS_AI_VERSION` follows.

The Response Tokens entry links #263, because anyone whose documents were silently marked processed with nothing extracted has to reset those records by hand; the fix cannot identify them retroactively.

## Testing

- `node scripts/run-tests.js --all` — 66 passed / 6 skipped / 0 failed. The changelog test pins the newest block against `PAPERLESS_AI_VERSION`, so the two cannot drift.
- The Changelog tab was rendered in a browser: the block reads as current, all seven entries carry their category label and the issue link resolves.
- eslint and prettier clean; no OpenAPI drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)