### PR TITLE
Stop refusing an OCR model fetch over a key the page cannot see

### DIFF
--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1624,16 +1624,13 @@ function initializeFormHandlers() {
         provider,
         ocrApiUrlInput?.value
       );
+      // Sent empty when the field is empty, which is the normal case: a saved
+      // key is never echoed back into a password field and one injected through
+      // the environment was never in the form to begin with. The route resolves
+      // it from OCR_API_KEY / MISTRAL_API_KEY, so only the server can tell
+      // whether a key exists — refusing here asked "did you just type one?"
+      // and reported the answer as "there is none".
       const apiKey = String(ocrApiKeyInput?.value || '').trim();
-
-      if (provider === 'mistral' && !apiKey) {
-        await zrDialog({
-          icon: 'warning',
-          title: 'Missing API key',
-          text: 'Mistral OCR requires an API key to load models.',
-        });
-        return;
-      }
 
       setButtonLoading(fetchOcrModelsBtn, true);
       try {

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -1846,17 +1846,9 @@ class SetupWizard {
       setupOcrValidationTimeoutMs: this.getOcrValidationTimeoutMs(),
     };
 
-    if (payload.provider === 'mistral' && !payload.apiKey) {
-      if (!silent) {
-        await this.showPopup({
-          icon: 'warning',
-          title: 'API key missing',
-          text: 'Mistral OCR requires an API key to discover models.',
-        });
-      }
-      return [];
-    }
-
+    // No local refusal on an empty field: an operator who already has
+    // MISTRAL_API_KEY in their compose file never types one here, and the route
+    // resolves it. Whether a key exists is the server's question to answer.
     this.setButtonLoading(this.fetchOcrModelsBtn, true, 'Loading...');
     try {
       const result = await this.request('/api/setup/ocr/models', payload);

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3936,7 +3936,10 @@ function resolveSettingsAiToken(aiProvider, token) {
   return normalizedToken || resolveStoredAiToken(aiProvider);
 }
 
-function resolveSettingsOcrApiKey(apiKey) {
+/* The key may be typed into the form, saved from an earlier save, or
+   injected through the environment. Only this side can see the last two, which
+   is why neither page refuses an empty field on its own. */
+function resolveOcrApiKey(apiKey) {
   const normalizedApiKey = String(apiKey || '').trim();
   return (
     normalizedApiKey ||
@@ -4976,7 +4979,9 @@ router.post('/api/setup/ocr/models', express.json(), async (req, res) => {
     const result = await discoverOcrModelsForSetup({
       provider: req.body?.provider,
       apiUrl: req.body?.apiUrl,
-      apiKey: req.body?.apiKey,
+      // The wizard used to take the field at face value, so an operator whose
+      // key already sat in the environment was told to supply one.
+      apiKey: resolveOcrApiKey(req.body?.apiKey),
       setupValidationTimeoutMs: req.body?.setupValidationTimeoutMs,
     });
 
@@ -5117,7 +5122,7 @@ router.post(
         enabled: req.body?.enabled,
         provider: req.body?.provider,
         apiUrl: req.body?.apiUrl,
-        apiKey: resolveSettingsOcrApiKey(req.body?.apiKey),
+        apiKey: resolveOcrApiKey(req.body?.apiKey),
         model: req.body?.model,
         setupOcrValidationTimeoutMs:
           req.body?.setupOcrValidationTimeoutMs ??
@@ -5184,7 +5189,7 @@ router.post(
       const result = await discoverOcrModelsForSetup({
         provider: req.body?.provider,
         apiUrl: req.body?.apiUrl,
-        apiKey: resolveSettingsOcrApiKey(req.body?.apiKey),
+        apiKey: resolveOcrApiKey(req.body?.apiKey),
         setupOcrValidationTimeoutMs:
           req.body?.setupOcrValidationTimeoutMs ??
           req.body?.setupValidationTimeoutMs,

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -88,6 +88,7 @@ const TESTS = {
     'test-mistral-ocr-no-processed-on-update-failure.js',
   'ocr-provider-lmstudio-compatible':
     'test-ocr-provider-lmstudio-compatible.js',
+  'ocr-model-fetch-key': 'test-ocr-model-fetch-key.js',
   'ocr-provider-ollama': 'test-ocr-provider-ollama.js',
   'ocr-pdf-render-multipage': 'test-ocr-pdf-render-multipage.js',
   'ocr-pdf-render-fallback': 'test-ocr-pdf-render-fallback.js',
@@ -122,6 +123,7 @@ const AREAS = {
     'document-metadata-batching',
     'mistral-ocr-no-processed-on-update-failure',
     'ocr-provider-lmstudio-compatible',
+    'ocr-model-fetch-key',
     'ocr-provider-ollama',
     'ocr-pdf-render-multipage',
     'ocr-pdf-render-fallback',

--- a/services/setupService.js
+++ b/services/setupService.js
@@ -927,7 +927,12 @@ class SetupService {
 
     if (provider === 'mistral') {
       if (!apiKey) {
-        throw new Error('API key is required for Mistral OCR model discovery');
+        // Reached only when the field, the saved configuration and the
+        // environment are all empty — the routes resolve the other two before
+        // asking. Naming all three saves the reader the guess.
+        throw new Error(
+          'Mistral OCR model discovery needs an API key. Enter one above, or set OCR_API_KEY or MISTRAL_API_KEY.'
+        );
       }
 
       const targetUrls = this.buildVersionedApiUrlCandidates(

--- a/tests/test-ocr-model-fetch-key.js
+++ b/tests/test-ocr-model-fetch-key.js
@@ -1,0 +1,129 @@
+/**
+ * "Fetch OCR models" must not refuse a key it cannot see.
+ *
+ * The key can sit in three places: the form field, the saved configuration, or
+ * the environment. Only the server sees the latter two — a saved key is never
+ * echoed back into a password field, and an injected one was never in the form.
+ * Both pages used to refuse an empty field on their own and report it as
+ * "Missing API key", so an instance configured through MISTRAL_API_KEY could
+ * never load its model list.
+ *
+ * The resolver is read out of the route file rather than copied, so this test
+ * cannot keep passing after the real one changes.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROUTE_FILE = path.join(__dirname, '..', 'routes', 'setup.js');
+const source = fs.readFileSync(ROUTE_FILE, 'utf8');
+
+const start = source.indexOf('function resolveOcrApiKey');
+assert.ok(
+  start !== -1,
+  'Could not find resolveOcrApiKey in routes/setup.js — did it move or get renamed?'
+);
+const end = source.indexOf('\n}', start);
+const resolveOcrApiKey = new Function(
+  `${source.slice(start, end + 2)}\nreturn resolveOcrApiKey;`
+)();
+
+let failed = 0;
+const check = (label, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${label}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`  ✗ ${label}: ${error.message}`);
+  }
+};
+
+const originalOcr = process.env.OCR_API_KEY;
+const originalMistral = process.env.MISTRAL_API_KEY;
+const restore = () => {
+  if (originalOcr === undefined) delete process.env.OCR_API_KEY;
+  else process.env.OCR_API_KEY = originalOcr;
+  if (originalMistral === undefined) delete process.env.MISTRAL_API_KEY;
+  else process.env.MISTRAL_API_KEY = originalMistral;
+};
+
+console.log('\n=== OCR model discovery: key resolution ===');
+
+check('what the operator typed wins', () => {
+  process.env.OCR_API_KEY = 'from-env';
+  assert.strictEqual(
+    resolveOcrApiKey('typed-in-the-form'),
+    'typed-in-the-form'
+  );
+});
+
+check('an empty field falls back to OCR_API_KEY', () => {
+  process.env.OCR_API_KEY = 'from-ocr-var';
+  delete process.env.MISTRAL_API_KEY;
+  assert.strictEqual(resolveOcrApiKey(''), 'from-ocr-var');
+  assert.strictEqual(resolveOcrApiKey(undefined), 'from-ocr-var');
+  // Whitespace is what a cleared field actually leaves behind.
+  assert.strictEqual(resolveOcrApiKey('   '), 'from-ocr-var');
+});
+
+check('MISTRAL_API_KEY is the second source', () => {
+  delete process.env.OCR_API_KEY;
+  process.env.MISTRAL_API_KEY = 'from-mistral-var';
+  assert.strictEqual(resolveOcrApiKey(''), 'from-mistral-var');
+});
+
+check('nothing anywhere resolves to empty, not to a placeholder', () => {
+  delete process.env.OCR_API_KEY;
+  delete process.env.MISTRAL_API_KEY;
+  assert.strictEqual(resolveOcrApiKey(''), '');
+});
+
+restore();
+
+/* --- neither page may refuse on its own ------------------------------- */
+
+const settingsSource = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'js', 'settings.js'),
+  'utf8'
+);
+const wizardSource = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'js', 'setup.js'),
+  'utf8'
+);
+
+check('the settings page no longer blocks on an empty field', () => {
+  assert.ok(
+    !settingsSource.includes('Mistral OCR requires an API key to load models'),
+    'the client-side refusal is back in settings.js'
+  );
+});
+
+check('the setup wizard no longer blocks on an empty field', () => {
+  assert.ok(
+    !wizardSource.includes(
+      'Mistral OCR requires an API key to discover models'
+    ),
+    'the client-side refusal is back in setup.js'
+  );
+});
+
+check('every OCR route resolves the key before using it', () => {
+  // /api/setup/ocr/models, /api/settings/ocr/test and
+  // /api/settings/ocr/models. The wizard was the one passing req.body.apiKey
+  // straight through; the settings test endpoint always resolved.
+  const calls = (source.match(/resolveOcrApiKey\(req\.body\?\.apiKey\)/g) || [])
+    .length;
+  assert.strictEqual(
+    calls,
+    3,
+    `expected 3 resolved call sites, found ${calls}`
+  );
+});
+
+if (failed > 0) {
+  console.error(`\n${failed} OCR key resolution case(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll OCR key resolution cases passed');


### PR DESCRIPTION
"Fetch OCR models" answered **"Missing API key — Mistral OCR requires an API key to load models"** on instances that had one.

The key can sit in three places: the form field, the saved configuration, or the environment. **Only the server sees the last two** — a saved key is never echoed back into a password field, and one injected through `MISTRAL_API_KEY` was never in the form to begin with.

Both pages checked the field and reported the answer as though they had checked for a key:

```js
const apiKey = String(ocrApiKeyInput?.value || '').trim();
if (provider === 'mistral' && !apiKey) { …refuse… }
```

The settings route resolves `OCR_API_KEY` and `MISTRAL_API_KEY` itself and would have succeeded. It was simply never reached. The setup wizard had the same refusal and, behind it, passed `req.body.apiKey` straight through — so an operator whose key already sat in their compose file was told to supply one.

## Changes

Neither page refuses on its own any more; whether a key exists is the server's question, and answering it in the browser is what produced a wrong answer. The wizard route now resolves the key like the two settings routes do, and `resolveSettingsOcrApiKey` became `resolveOcrApiKey` since all three share it.

When there really is no key anywhere, `setupService` names all three places to put one instead of "API key is required for Mistral OCR model discovery".

## Testing

- `node scripts/run-tests.js --all` — **67 passed / 6 skipped / 0 failed**.
- The new test reads the resolver out of the route file rather than copying it, covers the precedence (typed wins → `OCR_API_KEY` → `MISTRAL_API_KEY` → empty), and pins both the absence of the two client-side refusals and the **three** resolved call sites — the wizard was the one missing.
- Driven in a browser against a stub that resolves server-side: empty field plus a key in the environment loads the model list; no key anywhere gives "Mistral OCR model discovery needs an API key. Enter one above, or set OCR_API_KEY or MISTRAL_API_KEY."
- eslint and prettier clean; no OpenAPI drift.

## Impact

Instances configured through the environment or an earlier save can load their OCR model list. Nothing changes for someone typing a key into the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)