### PR TITLE
Fix OCR model discovery, scan endpoint, and settings quickstart

### DIFF
--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -2902,6 +2902,101 @@
         }
       }
     },
+    "/api/settings/ocr/models": {
+      "post": {
+        "summary": "Discover available OCR models from the settings page",
+        "description": "Returns every discovered model that is not embedding-only. Vision\nsupport is detected from the model name, which recognizes families\nsuch as llava or pixtral and misses OCR-capable models with\nunremarkable names, so it ranks the list instead of filtering it:\n`visionModels` and `suggestedModel` are hints for the UI, not a\nrestriction on what may be selected.\n",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "enum": [
+                      "mistral",
+                      "custom",
+                      "ollama"
+                    ]
+                  },
+                  "apiUrl": {
+                    "type": "string"
+                  },
+                  "apiKey": {
+                    "type": "string",
+                    "description": "Omit or leave empty to use the stored OCR_API_KEY / MISTRAL_API_KEY"
+                  },
+                  "setupOcrValidationTimeoutMs": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OCR model list returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "models": {
+                      "type": "array",
+                      "description": "Every selectable OCR model (embedding-only models excluded)",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "visionModels": {
+                      "type": "array",
+                      "description": "Subset of models whose name indicates vision support; absent for providers without model classification",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "suggestedModel": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Recommended default; absent for providers without model classification"
+                    },
+                    "resolvedApiUrl": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Model discovery failed"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
     "/api/settings/quickstart/detect": {
       "post": {
         "summary": "Auto-detect API flavor and classify models from a single base URL",

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1040,6 +1040,16 @@ function initializeFormHandlers() {
       );
     }
 
+    // The recommended/other grouping in the model dropdown only exists on the
+    // classification path, which the Mistral provider does not take.
+    const ocrModelVisionHint = document.getElementById('ocrModelVisionHint');
+    if (ocrModelVisionHint) {
+      ocrModelVisionHint.classList.toggle(
+        'hidden',
+        !enabled || provider !== 'custom'
+      );
+    }
+
     // PDF page rendering only applies to local vision models; the Mistral
     // provider handles PDFs natively.
     const ocrPdfRenderContainer = document.getElementById(

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -899,6 +899,16 @@ class SetupWizard {
         provider !== 'custom' || !enabled
       );
     }
+
+    // The recommended/other grouping in the model dropdown only exists on the
+    // classification path, which the Mistral provider does not take.
+    const ocrModelVisionHint = document.getElementById('ocrModelVisionHint');
+    if (ocrModelVisionHint) {
+      ocrModelVisionHint.classList.toggle(
+        'hidden',
+        provider !== 'custom' || !enabled
+      );
+    }
   }
 
   normalizeOcrApiUrlForProvider(provider, rawUrl) {

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3058,7 +3058,6 @@ async function processDocument(
   existingTags,
   existingCorrespondentList,
   existingDocumentTypesList,
-  ownUserId,
   customPrompt = null
 ) {
   const isProcessed = await documentModel.isDocumentProcessed(doc.id);
@@ -3969,15 +3968,56 @@ function normalizeDocumentIdList(input) {
    than "no key" — the same rule the AI and OCR fields on that page follow. A
    saved key is never echoed back into the password input, so only this side
    can tell the two apart. Setup has no stored configuration to fall back on
-   and therefore does not use this. */
-function resolveSettingsQuickstartApiKey(apiKey) {
+   and therefore does not use this.
+
+   Two conditions, both necessary. The key belongs to the configured provider,
+   so it is resolved through resolveStoredAiToken() rather than by trying one
+   variable after another — a stale CUSTOM_API_KEY left over from a provider
+   switch must not be sent to an Ollama host. And it is only substituted when
+   the request targets that provider's own server: the settings page keeps
+   saved secrets out of the DOM on purpose, and an endpoint that forwards one
+   to any URL the caller names would hand it back out again. Typed keys are
+   always honoured, whatever the target. */
+function resolveSettingsQuickstartApiKey(baseUrl, apiKey) {
   const normalizedApiKey = String(apiKey || '').trim();
-  return (
-    normalizedApiKey ||
-    process.env.CUSTOM_API_KEY ||
-    process.env.OLLAMA_API_KEY ||
-    ''
-  );
+  if (normalizedApiKey) {
+    return normalizedApiKey;
+  }
+
+  const provider = String(process.env.AI_PROVIDER || '')
+    .trim()
+    .toLowerCase();
+  const configuredUrl =
+    provider === 'ollama'
+      ? process.env.OLLAMA_API_URL
+      : provider === 'custom'
+        ? process.env.CUSTOM_BASE_URL
+        : '';
+
+  return isSameQuickstartHost(baseUrl, configuredUrl)
+    ? resolveStoredAiToken(provider)
+    : '';
+}
+
+/* Compares the detection target with the configured AI server. The Quickstart
+   field is written by hand and normalizeBaseUrls() strips /v1 and trailing
+   slashes, so "http://host:1234/v1/" and "http://host:1234" are the same
+   server; anything that does not parse is not. */
+function isSameQuickstartHost(requestedUrl, configuredUrl) {
+  const normalize = (value) => {
+    const trimmed = String(value || '').trim();
+    if (!trimmed) return null;
+    try {
+      const parsed = new URL(trimmed);
+      return `${parsed.protocol}//${parsed.host}`.toLowerCase();
+    } catch {
+      return null;
+    }
+  };
+
+  const requested = normalize(requestedUrl);
+  const configured = normalize(configuredUrl);
+  return Boolean(requested && configured && requested === configured);
 }
 
 /* The key may be typed into the form, saved from an earlier save, or
@@ -5001,7 +5041,12 @@ router.post('/api/setup/ocr/test', express.json(), async (req, res) => {
       apiUrl: req.body?.apiUrl,
       apiKey: req.body?.apiKey,
       model: req.body?.model,
-      setupValidationTimeoutMs: req.body?.setupValidationTimeoutMs,
+      // The OCR helpers take setupOcrValidationTimeoutMs, which is also what
+      // the wizard sends; passing it under the AI key dropped the configured
+      // OCR timeout on the floor and fell back to the global default.
+      setupOcrValidationTimeoutMs:
+        req.body?.setupOcrValidationTimeoutMs ??
+        req.body?.setupValidationTimeoutMs,
     });
 
     return res.json(validation);
@@ -5071,7 +5116,13 @@ router.post('/api/setup/ocr/models', express.json(), async (req, res) => {
       // The wizard used to take the field at face value, so an operator whose
       // key already sat in the environment was told to supply one.
       apiKey: resolveOcrApiKey(req.body?.apiKey),
-      setupValidationTimeoutMs: req.body?.setupValidationTimeoutMs,
+      // Same key mismatch as in /api/setup/ocr/test above: the discovery
+      // helper takes setupOcrValidationTimeoutMs. It matters here because
+      // classifying an Ollama catalogue costs one /api/show per model and
+      // runs against a deadline derived from this timeout.
+      setupOcrValidationTimeoutMs:
+        req.body?.setupOcrValidationTimeoutMs ??
+        req.body?.setupValidationTimeoutMs,
     });
 
     return res.json(result);
@@ -5269,6 +5320,73 @@ router.get('/api/settings/ai/presets', isAuthenticated, async (_req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/settings/ocr/models:
+ *   post:
+ *     summary: Discover available OCR models from the settings page
+ *     description: |
+ *       Returns every discovered model that is not embedding-only. Vision
+ *       support is detected from the model name, which recognizes families
+ *       such as llava or pixtral and misses OCR-capable models with
+ *       unremarkable names, so it ranks the list instead of filtering it:
+ *       `visionModels` and `suggestedModel` are hints for the UI, not a
+ *       restriction on what may be selected.
+ *     tags:
+ *       - Settings
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               provider:
+ *                 type: string
+ *                 enum: [mistral, custom, ollama]
+ *               apiUrl:
+ *                 type: string
+ *               apiKey:
+ *                 type: string
+ *                 description: Omit or leave empty to use the stored OCR_API_KEY / MISTRAL_API_KEY
+ *               setupOcrValidationTimeoutMs:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: OCR model list returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 models:
+ *                   type: array
+ *                   description: Every selectable OCR model (embedding-only models excluded)
+ *                   items:
+ *                     type: string
+ *                 visionModels:
+ *                   type: array
+ *                   description: Subset of models whose name indicates vision support; absent for providers without model classification
+ *                   items:
+ *                     type: string
+ *                 suggestedModel:
+ *                   type: string
+ *                   nullable: true
+ *                   description: Recommended default; absent for providers without model classification
+ *                 resolvedApiUrl:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Model discovery failed
+ *       401:
+ *         description: Unauthorized
+ */
 router.post(
   '/api/settings/ocr/models',
   isAuthenticated,
@@ -5339,8 +5457,12 @@ router.post(
       const result = await detectQuickstartForSetup({
         baseUrl: req.body?.baseUrl,
         // An empty field means the stored key, not no key: the settings page
-        // never renders a saved secret back into the input.
-        apiKey: resolveSettingsQuickstartApiKey(req.body?.apiKey),
+        // never renders a saved secret back into the input. Only for the
+        // configured AI server, though — see the resolver.
+        apiKey: resolveSettingsQuickstartApiKey(
+          req.body?.baseUrl,
+          req.body?.apiKey
+        ),
         setupValidationTimeoutMs: req.body?.setupValidationTimeoutMs,
       });
 
@@ -6118,21 +6240,17 @@ async function processQueue(customPrompt) {
       return;
     }
 
-    // The own user ID is resolved with the lists below and handed to
-    // processDocument(), which does not act on it. It must therefore not gate
-    // the queue: an unresolvable ID used to abort manual processing outright
-    // (issue #305).
-    const [
-      existingTags,
-      existingCorrespondentList,
-      existingDocumentTypes,
-      ownUserId,
-    ] = await Promise.all([
-      paperlessService.getTags(),
-      paperlessService.listCorrespondentsNames(),
-      paperlessService.listDocumentTypesNames(),
-      paperlessService.getOwnUserID(),
-    ]);
+    // No own-user-ID lookup here: it was resolved, threaded through two call
+    // frames and dropped, since processDocument() never reads it. It also used
+    // to gate the queue — an unresolvable ID aborted manual processing
+    // outright (issue #305) — so this drops the guard, the request and the
+    // warning it would now log once per run.
+    const [existingTags, existingCorrespondentList, existingDocumentTypes] =
+      await Promise.all([
+        paperlessService.getTags(),
+        paperlessService.listCorrespondentsNames(),
+        paperlessService.listDocumentTypesNames(),
+      ]);
 
     // The paperlessService helpers return entity objects, so every list has to
     // be reduced to plain names before it reaches the AI services — otherwise
@@ -6150,7 +6268,6 @@ async function processQueue(customPrompt) {
           existingTagNames,
           existingCorrespondentNames,
           existingDocumentTypesList,
-          ownUserId,
           customPrompt
         );
         if (!result) continue;

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1759,32 +1759,45 @@ class PaperlessService {
           ? this._findDocumentById(normalizedQuery, documentFields)
           : null;
 
-      let response;
+      let results = [];
       try {
-        response = await this.client.get('/documents/', { params });
+        let response;
+        try {
+          response = await this.client.get('/documents/', { params });
+        } catch (error) {
+          // Full-text search needs the Paperless-ngx search index and rejects
+          // malformed query syntax. Keep the selector usable by retrying with a
+          // plain title filter instead of returning nothing.
+          if (mode !== 'all') {
+            throw error;
+          }
+
+          console.warn(
+            `[DEBUG] Full-text document search failed (${error.message}), retrying with a title filter`
+          );
+
+          const fallbackParams = { ...params };
+          delete fallbackParams.query;
+          fallbackParams.title__icontains = normalizedQuery;
+          response = await this.client.get('/documents/', {
+            params: fallbackParams,
+          });
+        }
+
+        results = Array.isArray(response?.data?.results)
+          ? response.data.results
+          : [];
       } catch (error) {
-        // Full-text search needs the Paperless-ngx search index and rejects
-        // malformed query syntax. Keep the selector usable by retrying with a
-        // plain title filter instead of returning nothing.
+        // A broken search index takes both attempts down with it. An exact ID
+        // hit does not depend on the index and is the answer the user asked
+        // for, so it must survive the failure rather than be discarded on the
+        // way out.
         if (mode !== 'all') {
           throw error;
         }
 
-        console.warn(
-          `[DEBUG] Full-text document search failed (${error.message}), retrying with a title filter`
-        );
-
-        const fallbackParams = { ...params };
-        delete fallbackParams.query;
-        fallbackParams.title__icontains = normalizedQuery;
-        response = await this.client.get('/documents/', {
-          params: fallbackParams,
-        });
+        console.error('[ERROR] searching documents:', error.message);
       }
-
-      const results = Array.isArray(response?.data?.results)
-        ? response.data.results
-        : [];
 
       const idMatch = idLookup ? await idLookup : null;
       if (!idMatch) {

--- a/tests/test-scan-now-user-id-independence.js
+++ b/tests/test-scan-now-user-id-independence.js
@@ -10,9 +10,15 @@
  * case difference, or a response the token user cannot fully see all ended in
  * the same silent null.
  *
- * The scan does not use the user ID (processDocument() takes it and ignores
- * it), so neither the endpoint nor the queue may gate on it. The route file is
- * read here rather than copied so the assertions cannot drift away from it.
+ * The scan does not use the user ID at all, so neither the endpoint nor the
+ * queue may gate on it — and since processDocument() never read the value it
+ * was handed, the plumbing is gone rather than merely ungated. That leaves
+ * getOwnUserID() with no caller in the processing path; it stays on the
+ * service as a general Paperless helper, hardened, and is covered below so a
+ * future caller inherits the fixed behaviour rather than the old one.
+ *
+ * The route file is read here rather than copied so the assertions cannot
+ * drift away from it.
  */
 
 const assert = require('assert');
@@ -55,6 +61,18 @@ assert.ok(
 assert.ok(
   !routeSource.includes('Failed to get own user ID. Abort scanning.'),
   'Queue processing must not abort when the user ID cannot be resolved — the same dead guard stopped manual processing outright'
+);
+
+// The ID was resolved, passed to processDocument() and never read there, so
+// the whole thread is gone: no request per queue run, and no warning logged
+// about a value nothing consumes.
+assert.ok(
+  !routeSource.includes('ownUserId'),
+  'routes/setup.js must not thread an own-user ID it never reads through processDocument()'
+);
+assert.ok(
+  !routeSource.includes('getOwnUserID'),
+  'No route may call getOwnUserID — nothing in the processing path uses the result'
 );
 
 // ── getOwnUserID() resolves the current user without a name match ────────────

--- a/tests/test-search-documents-exact-id.js
+++ b/tests/test-search-documents-exact-id.js
@@ -20,12 +20,18 @@ async function run() {
     // Search results returned for the full-text endpoint; individual assertions
     // reassign this to shape what /documents/ answers with.
     let searchResults = [];
+    // Flipped on to simulate an unusable Paperless-ngx search index, which
+    // fails the full-text query and its title fallback alike.
+    let searchThrows = false;
 
     paperlessService.client = {
       get: async (url, options) => {
         calls.push(url);
         if (url === '/documents/') {
           searchParams.push(options?.params || {});
+          if (searchThrows) {
+            throw new Error('search index is broken');
+          }
           return { data: { results: searchResults } };
         }
         if (url === '/documents/1431/') {
@@ -212,6 +218,41 @@ async function run() {
       ['/documents/'],
       'the title scope must not run an ID lookup'
     );
+
+    // A broken Paperless-ngx search index takes the full-text query and its
+    // title fallback down together. The ID lookup does not use the index, so
+    // its hit must survive rather than be discarded on the way out.
+    calls.length = 0;
+    errorLogs.length = 0;
+    searchThrows = true;
+    const indexDown = await paperlessService.searchDocuments(
+      '1431',
+      100,
+      'all'
+    );
+    assert.deepStrictEqual(
+      indexDown.map((doc) => doc.id),
+      [1431],
+      'an exact ID hit must survive a failing full-text search'
+    );
+    assert.ok(
+      errorLogs.some((line) => line.includes('search index is broken')),
+      'the search failure must still be logged'
+    );
+
+    // With nothing to fall back on, a failing search is still an empty result.
+    calls.length = 0;
+    const indexDownNoId = await paperlessService.searchDocuments(
+      'Rechnung',
+      100,
+      'all'
+    );
+    assert.deepStrictEqual(
+      indexDownNoId,
+      [],
+      'a failing search with no ID candidate still returns nothing'
+    );
+    searchThrows = false;
 
     console.log('PASS test-search-documents-exact-id');
   } finally {

--- a/tests/test-settings-quickstart-persistence.js
+++ b/tests/test-settings-quickstart-persistence.js
@@ -15,8 +15,15 @@
  * resolves the stored one. That is the same contract the AI and OCR key fields
  * on this page already follow.
  *
- * The resolver is read out of the route file rather than copied, so this test
- * cannot keep passing after the real one changes.
+ * Two conditions bound that substitution, and both are load-bearing. The key
+ * is resolved for the configured provider, so a CUSTOM_API_KEY left behind by
+ * a provider switch is not sent to an Ollama host. And it is only substituted
+ * when the request targets that provider's own server, so an endpoint that
+ * accepts an arbitrary baseUrl cannot be used to read a secret the page
+ * deliberately never renders.
+ *
+ * The resolvers are read out of the route file rather than copied, so this
+ * test cannot keep passing after the real ones change.
  */
 
 const assert = require('assert');
@@ -31,68 +38,135 @@ const viewSource = fs.readFileSync(VIEW_FILE, 'utf8');
 
 // ── The stored key stands in for an empty field ──────────────────────────────
 
-const start = routeSource.indexOf('function resolveSettingsQuickstartApiKey');
-assert.ok(
-  start !== -1,
-  'Could not find resolveSettingsQuickstartApiKey in routes/setup.js — did it move or get renamed?'
-);
-const end = routeSource.indexOf('\n}', start);
+function extract(name, declaration) {
+  const start = routeSource.indexOf(declaration);
+  assert.ok(
+    start !== -1,
+    `Could not find ${name} in routes/setup.js — did it move or get renamed?`
+  );
+  const end = routeSource.indexOf('\n}', start);
+  assert.ok(end > start, `Could not delimit ${name}`);
+  return routeSource.slice(start, end + 2);
+}
+
+// resolveSettingsQuickstartApiKey leans on both of these, so all three come
+// out of the route file together.
 const resolveSettingsQuickstartApiKey = new Function(
-  `${routeSource.slice(start, end + 2)}\nreturn resolveSettingsQuickstartApiKey;`
+  `${extract('resolveStoredAiToken', 'function resolveStoredAiToken')}
+   ${extract('isSameQuickstartHost', 'function isSameQuickstartHost')}
+   ${extract('resolveSettingsQuickstartApiKey', 'function resolveSettingsQuickstartApiKey')}
+   return resolveSettingsQuickstartApiKey;`
 )();
 
-const originalCustom = process.env.CUSTOM_API_KEY;
-const originalOllama = process.env.OLLAMA_API_KEY;
+const CONFIGURED = 'http://192.168.1.5:1234';
+const ELSEWHERE = 'https://attacker.example';
+
+const savedEnv = {
+  AI_PROVIDER: process.env.AI_PROVIDER,
+  CUSTOM_API_KEY: process.env.CUSTOM_API_KEY,
+  CUSTOM_BASE_URL: process.env.CUSTOM_BASE_URL,
+  OLLAMA_API_KEY: process.env.OLLAMA_API_KEY,
+  OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+};
 
 try {
+  // ── Custom provider ────────────────────────────────────────────────────────
+  process.env.AI_PROVIDER = 'custom';
+  process.env.CUSTOM_BASE_URL = CONFIGURED;
   process.env.CUSTOM_API_KEY = 'stored-custom-key';
-  delete process.env.OLLAMA_API_KEY;
+  // Left behind by an earlier provider switch — must never be reached for.
+  process.env.OLLAMA_API_URL = 'http://192.168.2.100:11434';
+  process.env.OLLAMA_API_KEY = 'stored-ollama-key';
 
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey('typed-key'),
+    resolveSettingsQuickstartApiKey(CONFIGURED, 'typed-key'),
     'typed-key',
     'A key typed into the field must win over the stored one'
   );
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey('  typed-key  '),
+    resolveSettingsQuickstartApiKey(ELSEWHERE, '  typed-key  '),
     'typed-key',
-    'Surrounding whitespace must be trimmed'
+    'A typed key is honoured whatever the target, and is trimmed'
   );
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey(''),
+    resolveSettingsQuickstartApiKey(CONFIGURED, ''),
     'stored-custom-key',
-    'An empty field must fall back to the stored custom key'
+    'An empty field must fall back to the stored key of the configured provider'
   );
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey(undefined),
+    resolveSettingsQuickstartApiKey(CONFIGURED, undefined),
     'stored-custom-key',
-    'A missing field must fall back to the stored custom key'
+    'A missing field behaves like an empty one'
   );
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey('   '),
+    resolveSettingsQuickstartApiKey(CONFIGURED, '   '),
     'stored-custom-key',
     'A whitespace-only field counts as empty'
   );
 
-  delete process.env.CUSTOM_API_KEY;
-  process.env.OLLAMA_API_KEY = 'stored-ollama-key';
+  // Same server, written the way the Quickstart field accepts it.
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey(''),
+    resolveSettingsQuickstartApiKey('http://192.168.1.5:1234/v1/', ''),
+    'stored-custom-key',
+    'A /v1 suffix and a trailing slash still name the configured server'
+  );
+
+  // The exfiltration case: any other host gets nothing.
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey(ELSEWHERE, ''),
+    '',
+    'A stored key must never be forwarded to a host the caller names — the settings page keeps saved secrets out of the DOM on purpose'
+  );
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey('http://192.168.1.5:9999', ''),
+    '',
+    'A different port is a different server'
+  );
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey('not a url', ''),
+    '',
+    'An unparseable target matches nothing'
+  );
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey('', ''),
+    '',
+    'A missing target matches nothing'
+  );
+
+  // ── Ollama provider ────────────────────────────────────────────────────────
+  process.env.AI_PROVIDER = 'ollama';
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey('http://192.168.2.100:11434', ''),
     'stored-ollama-key',
     'An Ollama setup must fall back to its own stored key'
   );
-
-  delete process.env.OLLAMA_API_KEY;
   assert.strictEqual(
-    resolveSettingsQuickstartApiKey(''),
+    resolveSettingsQuickstartApiKey(CONFIGURED, ''),
+    '',
+    'The custom key must not be sent to the Ollama host, or vice versa — a stale key from a provider switch would 401 and leak'
+  );
+
+  // ── Providers with no local server ─────────────────────────────────────────
+  process.env.AI_PROVIDER = 'openai';
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey(CONFIGURED, ''),
+    '',
+    'OpenAI and Azure have no Quickstart-detectable server, so nothing is substituted'
+  );
+
+  // ── Nothing stored ─────────────────────────────────────────────────────────
+  process.env.AI_PROVIDER = 'custom';
+  delete process.env.CUSTOM_API_KEY;
+  assert.strictEqual(
+    resolveSettingsQuickstartApiKey(CONFIGURED, ''),
     '',
     'With nothing stored the detection runs without a key, as before'
   );
 } finally {
-  if (originalCustom === undefined) delete process.env.CUSTOM_API_KEY;
-  else process.env.CUSTOM_API_KEY = originalCustom;
-  if (originalOllama === undefined) delete process.env.OLLAMA_API_KEY;
-  else process.env.OLLAMA_API_KEY = originalOllama;
+  Object.entries(savedEnv).forEach(([key, value]) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  });
 }
 
 // ── The settings route uses it; setup must not ───────────────────────────────
@@ -106,8 +180,10 @@ const settingsRouteBody = routeSource.slice(
   routeSource.indexOf('\n);', settingsRouteStart)
 );
 assert.ok(
-  settingsRouteBody.includes('resolveSettingsQuickstartApiKey'),
-  'POST /api/settings/quickstart/detect must resolve the stored key for an empty field'
+  /resolveSettingsQuickstartApiKey\(\s*req\.body\?\.baseUrl,\s*req\.body\?\.apiKey\s*\)/.test(
+    settingsRouteBody
+  ),
+  'POST /api/settings/quickstart/detect must resolve the stored key for an empty field, and must pass the target URL so the resolver can refuse a host that is not the configured one'
 );
 
 const setupRouteStart = routeSource.indexOf("'/api/setup/quickstart/detect'");
@@ -134,20 +210,30 @@ const section = viewSource.slice(
 );
 
 assert.ok(
-  /id="settingsQuickstartUrl"[^>]*value="<%=\s*config\.CUSTOM_BASE_URL\s*\|\|\s*config\.OLLAMA_API_URL/.test(
+  /id="settingsQuickstartUrl"[^>]*value="<%=\s*quickstartUrl\s*%>"/.test(
     section
   ),
-  'The AI server URL must be prefilled from the configured AI server so the block is not blank after a restart'
+  'The AI server URL must be prefilled so the block is not blank after a restart'
+);
+assert.ok(
+  /const quickstartUrl\s*=[\s\S]*?quickstartProvider === 'ollama'[\s\S]*?quickstartProvider === 'custom'/.test(
+    section
+  ),
+  'The prefill must key on config.AI_PROVIDER: config.OLLAMA_API_URL carries a http://localhost:11434 default and is never empty, so a first-non-empty fallback hands every OpenAI or Azure install a localhost URL it never configured'
 );
 
 const keyField = section.slice(
   section.indexOf('id="settingsQuickstartApiKey"')
 );
 assert.ok(
-  /placeholder="<%=\s*\(configuredSecrets\.CUSTOM_API_KEY \|\| configuredSecrets\.OLLAMA_API_KEY\)/.test(
-    keyField
-  ),
+  /placeholder="<%=\s*quickstartKeyStored \?/.test(keyField),
   'The API key field must say when a key is already configured'
+);
+assert.ok(
+  /const quickstartKeyStored\s*=[\s\S]*?quickstartProvider === 'ollama'[\s\S]*?quickstartProvider === 'custom'/.test(
+    section
+  ),
+  'Whether a key is stored must be read for the configured provider, matching what the route will actually substitute'
 );
 assert.ok(
   !/id="settingsQuickstartApiKey"[^>]*value="<%/.test(section),

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -354,18 +354,34 @@
                                 </div>
                                 <div class="zr-module__body zr-col zr-col--loose">
                                 <p class="zr-field__hint">Point at a local AI server (LM Studio, Ollama, or any OpenAI-compatible endpoint). Detection lists the running models and classifies them for AI analysis and OCR. These two fields drive the detection run only &mdash; what gets saved is what you apply to the AI and OCR settings below.</p>
+<%
+/* Only the provider actually in use may prefill this field. config.OLLAMA_API_URL
+   carries a default of http://localhost:11434 and is therefore never empty, so
+   "whichever is set" would hand every OpenAI or Azure install a localhost URL it
+   never configured. The stored key follows the same provider, and the route
+   below only substitutes it when the detection targets that same server. */
+const quickstartProvider = String(config.AI_PROVIDER || '').toLowerCase();
+const quickstartUrl =
+    quickstartProvider === 'ollama' ? (config.OLLAMA_API_URL || '')
+    : quickstartProvider === 'custom' ? (config.CUSTOM_BASE_URL || '')
+    : '';
+const quickstartKeyStored =
+    quickstartProvider === 'ollama' ? Boolean(configuredSecrets.OLLAMA_API_KEY)
+    : quickstartProvider === 'custom' ? Boolean(configuredSecrets.CUSTOM_API_KEY)
+    : false;
+-%>
                                 <div class="zr-field zr-field--stacked">
                                     <label for="settingsQuickstartUrl" class="zr-field__name">AI server URL</label>
-                                    <input type="text" id="settingsQuickstartUrl" class="zr-input" value="<%= config.CUSTOM_BASE_URL || config.OLLAMA_API_URL || '' %>" placeholder="http://192.168.1.5:1234">
-                                    <% if (config.CUSTOM_BASE_URL || config.OLLAMA_API_URL) { %>
+                                    <input type="text" id="settingsQuickstartUrl" class="zr-input" value="<%= quickstartUrl %>" placeholder="http://192.168.1.5:1234">
+                                    <% if (quickstartUrl) { %>
                                         <p class="zr-field__hint">Prefilled from the configured AI server</p>
                                     <% } %>
                                 </div>
                                 <div class="zr-field zr-field--stacked">
                                     <label for="settingsQuickstartApiKey" class="zr-field__name">API key (optional)</label>
-                                    <input type="password" id="settingsQuickstartApiKey" class="zr-input" placeholder="<%= (configuredSecrets.CUSTOM_API_KEY || configuredSecrets.OLLAMA_API_KEY) ? 'Configured' : 'Optional' %>">
-                                    <% if (configuredSecrets.CUSTOM_API_KEY || configuredSecrets.OLLAMA_API_KEY) { %>
-                                        <p class="zr-field__hint">Leave empty to use the stored key</p>
+                                    <input type="password" id="settingsQuickstartApiKey" class="zr-input" placeholder="<%= quickstartKeyStored ? 'Configured' : 'Optional' %>">
+                                    <% if (quickstartKeyStored) { %>
+                                        <p class="zr-field__hint">Leave empty to use the stored key for this server</p>
                                     <% } %>
                                 </div>
                                 <div class="zr-row zr-row--wrap">
@@ -802,7 +818,8 @@
                                             <span>Fetch OCR Models</span>
                                         </button>
                                     </div>
-                                    <p class="zr-field__hint">Vision support is detected from the model name, so the list is grouped rather than filtered &middot; models outside the recommended group may still work &middot; Restart required</p>
+                                    <p id="ocrModelVisionHint" class="zr-field__hint <%= (config.OCR_PROVIDER || 'mistral') === 'mistral' ? 'hidden' : '' %>">Vision support is detected from the model name, so the list is grouped rather than filtered &middot; models outside the recommended group may still work</p>
+                                    <p class="zr-field__hint">Restart required</p>
                                 </div>
                                 <div id="ocrPdfRenderContainer" class="zr-col zr-col--loose">
                                     <%- include('partials/settings-switch', {

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -453,7 +453,7 @@
                                     <span>Fetch OCR models</span>
                                 </button>
                             </div>
-                            <p class="zr-field__hint">Vision support is detected from the model name, so the list is grouped rather than filtered &middot; models outside the recommended group may still work</p>
+                            <p id="ocrModelVisionHint" class="zr-field__hint <%= (config.OCR_PROVIDER || 'mistral') === 'mistral' ? 'hidden' : '' %>">Vision support is detected from the model name, so the list is grouped rather than filtered &middot; models outside the recommended group may still work</p>
                         </div>
                         <div class="zr-field zr-field--stacked">
                             <label for="ocrValidationTimeout" class="zr-field__name">OCR timeout</label>


### PR DESCRIPTION
## Summary

This release addresses three interconnected issues affecting document processing and setup:

1. **OCR model discovery was overly restrictive** — the vision name heuristic (llava, pixtral, etc.) was used as a filter rather than a ranking, hiding OCR-capable models with unremarkable names like gpt-4o and mistral-ocr-latest from the dropdown.

2. **POST /api/scan/now failed silently** — the endpoint tried to resolve the Paperless user ID and returned an unlogged 500 when it couldn't, even though the scan never uses that ID.

3. **Settings quickstart detection lost state on restart** — the Quickstart block's URL and key fields carried no name attribute, so they weren't persisted; worse, an empty key field (normal, since saved secrets aren't rendered) ran detection with no key at all.

## Key Changes

- **OCR model discovery (`discoverOcrModelsForSetup`):** Now returns all non-embedding models, with vision-capable ones reported separately in `visionModels` and `suggestedModel` for UI grouping. Vision detection remains a name heuristic that ranks the list rather than filtering it.

- **Scan endpoint (`POST /api/scan/now`):** Removed the user ID resolution guard that was causing silent 500s. The scan runs with the configured API token and never needs the numeric user ID. Added proper error logging for any remaining 500 responses.

- **Settings quickstart persistence:** 
  - Added `resolveSettingsQuickstartApiKey()` to substitute stored keys when the field is empty and the target is the configured server.
  - Added `isSameQuickstartHost()` to safely compare URLs (normalizes /v1 suffix and trailing slashes).
  - Updated the settings view to prefill the Quickstart URL from the configured AI server and explain that the key field uses the stored one when empty.

- **Document search (`searchDocuments`):** Enhanced to detect numeric terms and run an exact ID lookup in parallel with full-text search, returning the exact hit first if found. Falls back gracefully when the search index is broken.

- **UI model selects:** Both `public/js/settings.js` and `public/js/setup.js` now support optional grouping of models into "Recommended" (vision hits) and "Other models" sections, with the recommended group preselected.

- **Playground deprecation:** Removed from navigation, added a deprecation banner to the page itself, and marked both `/playground` and `/api/playground/bootstrap` routes as deprecated in OpenAPI docs.

## Testing

Added comprehensive regression tests:
- `test-ocr-model-discovery-unfiltered.js` — verifies the full model list is returned with vision hits reported separately
- `test-settings-quickstart-persistence.js` — validates key substitution logic and URL normalization
- `test-scan-now-user-id-independence.js` — confirms the scan endpoint no longer depends on user ID resolution
- `test-search-documents-exact-id.js` — extended to cover numeric term ID lookup and fallback behavior
- `test-playground-deprecation.js` — ensures the page is gone from navigation but still reachable with a deprecation warning

## Version

Bumped to v2026.08.04.

https://claude.ai/code/session_01NnBuCaE4MCo4oofaGuKrWH